### PR TITLE
Use Bool initializer instead of boolValue

### DIFF
--- a/Sources/Files.swift
+++ b/Sources/Files.swift
@@ -658,7 +658,7 @@ private extension FileManager {
             return nil
         }
         
-        if objCBool.boolValue {
+        if Bool(objCBool) {
             return .folder
         }
         


### PR DESCRIPTION
I'm trying to _dockerize_ some scripts and I had troubles compiling this on Linux. Here's the error message:

```
Compile Swift Module 'Files' (1 sources)
/Users/garriguv/github.com/garriguv/Files/Sources/Files.swift:661:12: error: value of type 'ObjCBool' (aka 'Bool') has no member 'boolValue'
        if objCBool.boolValue {
           ^~~~~~~~ ~~~~~~~~~
<unknown>:0: error: build had 1 command failures
error: exit(1): /usr/bin/swift-build-tool -f /Users/garriguv/github.com/garriguv/Files/.build/debug.yaml
```

This change allows the library to compile on Linux 🐧 