### PR TITLE
Fix create file at path method

### DIFF
--- a/Sources/Files.swift
+++ b/Sources/Files.swift
@@ -319,7 +319,7 @@ public class FileSystem {
         }
 
         do {
-            let name = path.substring(from: path.index(path.startIndex, offsetBy: parentPath.characters.count))
+            let name = path.substring(from: path.index(path.startIndex, offsetBy: parentPath.characters.count + 1))
             return try createFolder(at: parentPath).createFile(named: name, contents: contents)
         } catch {
             throw File.Error.writeFailed

--- a/Tests/FilesTests/FilesTests.swift
+++ b/Tests/FilesTests/FilesTests.swift
@@ -437,9 +437,14 @@ class FilesTests: XCTestCase {
 
     func testCreatingFileFromFileSystem() {
         performTest {
-            let filePath = folder.path + "one/two/three"
+            let fileName = "three"
+            let filePath = folder.path + "one/two/\(fileName)"
             let contents = Data()
-            try FileSystem().createFile(at: filePath, contents: contents)
+            let file = try FileSystem().createFile(at: filePath, contents: contents)
+
+            XCTAssertEqual(file.name, fileName)
+            XCTAssertEqual(file.path, filePath)
+
             try XCTAssertEqual(File(path: filePath).read(), contents)
         }
     }


### PR DESCRIPTION
Fixed https://github.com/JohnSundell/Marathon/issues/21

The error I fixed is like this,
```
Test Case '-[Files_iOS_Tests.FilesTests testCreatingFileFromFileSystem]' started.
/Users/pixyzehn/Developer/projects/Files/Tests/FilesTests/FilesTests.swift:446: error: -[Files_iOS_Tests.FilesTests testCreatingFileFromFileSystem] : XCTAssertEqual failed: ("/Users/pixyzehn/Library/Developer/CoreSimulator/Devices/CBC21E18-DBF9-40C5-B3C7-A17E671E1292/data/tmp/one/two//three") is not equal to ("/Users/pixyzehn/Library/Developer/CoreSimulator/Devices/CBC21E18-DBF9-40C5-B3C7-A17E671E1292/data/tmp/one/two/three") - 
```