### PR TITLE
Add syntactic sugar to reach the current folder.

### DIFF
--- a/Sources/Files.swift
+++ b/Sources/Files.swift
@@ -485,6 +485,11 @@ public final class Folder: FileSystem.Item, FileSystemIterable {
     public var subfolders: FileSystemSequence<Folder> {
         return makeSubfolderSequence()
     }
+
+    /// A reference to the folder that is the current working directory.
+    public static var current: Folder {
+        return try! Folder(path: "")
+    }
     
     /**
      *  Initialize an instance of this class with a path pointing to a folder

--- a/Sources/Files.swift
+++ b/Sources/Files.swift
@@ -486,9 +486,19 @@ public final class Folder: FileSystem.Item, FileSystemIterable {
         return makeSubfolderSequence()
     }
 
-    /// A reference to the folder that is the current working directory.
+    /// A reference to the folder that is the current working directory
     public static var current: Folder {
-        return try! Folder(path: "")
+        return FileSystem(using: .default).currentFolder
+    }
+
+    /// A reference to the current user's home folder
+    public static var home: Folder {
+        return FileSystem(using: .default).homeFolder
+    }
+
+    /// A reference to the temporary folder used by this file system
+    public static var temporary: Folder {
+        return FileSystem(using: .default).temporaryFolder
     }
     
     /**

--- a/Tests/FilesTests/FilesTests.swift
+++ b/Tests/FilesTests/FilesTests.swift
@@ -426,6 +426,7 @@ class FilesTests: XCTestCase {
     
     func testAccessingHomeFolder() {
         XCTAssertNotNil(FileSystem().homeFolder)
+        XCTAssertNotNil(Folder.home)
     }
 
     func testAccessingCurrentWorkingDirectory() {

--- a/Tests/FilesTests/FilesTests.swift
+++ b/Tests/FilesTests/FilesTests.swift
@@ -433,6 +433,7 @@ class FilesTests: XCTestCase {
             let folder = try Folder(path: "")
             XCTAssertEqual(FileManager.default.currentDirectoryPath + "/", folder.path)
             XCTAssertEqual(FileSystem().currentFolder, folder)
+            XCTAssertEqual(Folder.current, folder)
         }
     }
     


### PR DESCRIPTION
Add the possibility to reach the current folder with:
```swift
import Files

var current = Folder.current
```
This is an alternative to `FileSystem().currentFolder`.

We could imagine add the same for the home folder, temporary folder and so on.