### PR TITLE
FileSystem.Item: Add modifiedDate property

### DIFF
--- a/Sources/Files.swift
+++ b/Sources/Files.swift
@@ -161,7 +161,10 @@ public class FileSystem {
             
             return components.last
         }
-        
+
+        /// The date when the item was last modified
+        public private(set) lazy var modificationDate: Date = self.loadModificationDate()
+
         /// The folder that the item is contained in, or `nil` if this item is the root folder of the file system
         public var parent: Folder? {
             return fileManager.parentPath(for: path).flatMap { parentPath in
@@ -852,6 +855,11 @@ private extension FileSystem.Item {
                 return "Folder"
             }
         }
+    }
+
+    func loadModificationDate() -> Date {
+        let attributes = try! fileManager.attributesOfItem(atPath: path)
+        return attributes[FileAttributeKey.modificationDate] as! Date
     }
 }
 

--- a/Tests/FilesTests/FilesTests.swift
+++ b/Tests/FilesTests/FilesTests.swift
@@ -349,6 +349,16 @@ class FilesTests: XCTestCase {
             XCTAssertEqual(folder.files.last?.name, "C")
         }
     }
+
+    func testModificationDate() {
+        performTest {
+            let subfolder = try folder.createSubfolder(named: "Folder")
+            XCTAssertTrue(Calendar.current.isDateInToday(subfolder.modificationDate))
+
+            let file = try folder.createFile(named: "File")
+            XCTAssertTrue(Calendar.current.isDateInToday(file.modificationDate))
+        }
+    }
     
     func testParent() {
         performTest {


### PR DESCRIPTION
This change introduces a new property on `FileSystem.Item`; `modifiedDate`, which contains the date that the item was last modified on. Works for both `Files` and `Folders`.