### PR TITLE
Move hidden folder contents

### DIFF
--- a/Sources/Files.swift
+++ b/Sources/Files.swift
@@ -724,6 +724,7 @@ public final class Folder: FileSystem.Item, FileSystemIterable {
      *  Move the contents (both files and subfolders) of this folder to a new parent folder
      *
      *  - parameter newParent: The new parent folder that the contents of this folder should be moved to
+     *  - parameter includeHidden: Whether hidden (dot) files should be moved (default: false)
      */
     public func moveContents(to newParent: Folder, includeHidden: Bool = false) throws {
         try makeFileSequence(includeHidden: includeHidden).forEach { try $0.move(to: newParent) }

--- a/Sources/Files.swift
+++ b/Sources/Files.swift
@@ -725,9 +725,9 @@ public final class Folder: FileSystem.Item, FileSystemIterable {
      *
      *  - parameter newParent: The new parent folder that the contents of this folder should be moved to
      */
-    public func moveContents(to newParent: Folder) throws {
-        try files.forEach { try $0.move(to: newParent) }
-        try subfolders.forEach { try $0.move(to: newParent) }
+    public func moveContents(to newParent: Folder, includeHidden: Bool = false) throws {
+        try makeFileSequence(includeHidden: includeHidden).forEach { try $0.move(to: newParent) }
+        try makeSubfolderSequence(includeHidden: includeHidden).forEach { try $0.move(to: newParent) }
     }
     
     /**

--- a/Tests/FilesTests/FilesTests.swift
+++ b/Tests/FilesTests/FilesTests.swift
@@ -447,6 +447,25 @@ class FilesTests: XCTestCase {
         }
     }
     
+    func testMovingFolderHiddenContents() {
+        performTest {
+            let parentFolder = try folder.createSubfolder(named: "parent")
+            try parentFolder.createFile(named: ".hidden")
+            try parentFolder.createSubfolder(named: ".folder")
+            
+            XCTAssertEqual(parentFolder.makeFileSequence(includeHidden: true).names, [".hidden"])
+            XCTAssertEqual(parentFolder.makeSubfolderSequence(includeHidden: true).names, [".folder"])
+            
+            let newParentFolder = try folder.createSubfolder(named: "parentB")
+            try parentFolder.moveContents(to: newParentFolder, includeHidden: true)
+            
+            XCTAssertEqual(parentFolder.makeFileSequence(includeHidden: true).names, [])
+            XCTAssertEqual(parentFolder.makeSubfolderSequence(includeHidden: true).names, [])
+            XCTAssertEqual(newParentFolder.makeFileSequence(includeHidden: true).names, [".hidden"])
+            XCTAssertEqual(newParentFolder.makeSubfolderSequence(includeHidden: true).names, [".folder"])
+        }
+    }
+
     func testAccessingHomeFolder() {
         XCTAssertNotNil(FileSystem().homeFolder)
         XCTAssertNotNil(Folder.home)


### PR DESCRIPTION
I added an `includeHidden` parameter to `Folder.moveContents()` (that defaults to `false` so that the default behavior is unaffected) to allow for hidden files and folders to be moved. Came across the need for this functionality in a script I was writing where `.git` and `.gitignore` were not moved when using `moveContents()`.