### PR TITLE
Use Swift 4 version of the Package Description API

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,5 +1,26 @@
+// swift-tools-version:4.0
+
+/**
+ *  Files
+ *  Copyright (c) John Sundell 2017
+ *  Licensed under the MIT license. See LICENSE file.
+ */
+
 import PackageDescription
 
 let package = Package(
-    name: "Files"
+    name: "Files",
+    products: [
+        .library(name: "Files", targets: ["Files"])
+    ],
+    targets: [
+        .target(
+            name: "Files",
+            path: "Sources"
+        ),
+        .testTarget(
+            name: "FilesTests",
+            dependencies: ["Files"]
+        )
+    ]
 )


### PR DESCRIPTION
To tell SPM to use Swift 4 to compile the project.