### PR TITLE
Fix 45 - Moving a folder using move(to:) creates an invalid path

### DIFF
--- a/Sources/Files.swift
+++ b/Sources/Files.swift
@@ -287,8 +287,12 @@ public class FileSystem {
          *  - throws: `FileSystem.Item.OperationError.moveFailed` if the item couldn't be moved
          */
         public func move(to newParent: Folder) throws {
-            let newPath = newParent.path + name
-            
+            var newPath = newParent.path + name
+
+            if kind == .folder && !newPath.hasSuffix("/") {
+                newPath += "/"
+            }
+
             do {
                 try fileManager.moveItem(atPath: path, toPath: newPath)
                 path = newPath

--- a/Tests/FilesTests/FilesTests.swift
+++ b/Tests/FilesTests/FilesTests.swift
@@ -273,6 +273,18 @@ class FilesTests: XCTestCase {
             XCTAssertEqual(folder.files.count, 1)
         }
     }
+
+    func testMovingFolders() {
+        performTest {
+            let a = try folder.createSubfolder(named: "A")
+            let b = try a.createSubfolder(named: "B")
+            _ = try b.createSubfolder(named: "C")
+
+            try b.move(to: folder)
+            XCTAssertTrue(folder.containsSubfolder(named: "B"))
+            XCTAssertTrue(b.containsSubfolder(named: "C"))
+        }
+    }
     
     func testCopyingFolders() {
         performTest {


### PR DESCRIPTION
Fixes #45