### PR TITLE
Add append to file

### DIFF
--- a/Sources/Files.swift
+++ b/Sources/Files.swift
@@ -528,6 +528,29 @@ public final class File: FileSystem.Item, FileSystemIterable {
         
         try write(data: data)
     }
+
+    /**
+     *  Append data to the end of the file
+     *
+     *  - parameter data: The data to append to the file
+     *
+     *  - throws: `File.Error.writeFailed` if the file couldn't be written to
+     */
+    public func append(data: Data) throws {
+        // TODO: Implement
+    }
+
+    /**
+     *  Append a string to the end of the file
+     *
+     *  - parameter string: The string to append to the file
+     *  - parameter encoding: Optionally give which encoding that the string should be encoded in (defaults to UTF-8)
+     *
+     *  - throws: `File.Error.writeFailed` if the string couldn't be encoded, or written to the file
+     */
+    public func append(string: String, encoding: String.Encoding = .utf8) throws {
+        // TODO: Implement
+    }
     
     /**
      *  Copy this file to a new folder

--- a/Sources/Files.swift
+++ b/Sources/Files.swift
@@ -539,12 +539,9 @@ public final class File: FileSystem.Item, FileSystemIterable {
     public func append(data: Data) throws {
         do {
             let handle = try FileHandle(forWritingTo: URL(fileURLWithPath: path))
-            defer {
-                handle.closeFile()
-            }
-
             handle.seekToEndOfFile()
             handle.write(data)
+            handle.closeFile()
         } catch {
             throw Error.writeFailed
         }

--- a/Sources/Files.swift
+++ b/Sources/Files.swift
@@ -537,7 +537,17 @@ public final class File: FileSystem.Item, FileSystemIterable {
      *  - throws: `File.Error.writeFailed` if the file couldn't be written to
      */
     public func append(data: Data) throws {
-        // TODO: Implement
+        do {
+            let handle = try FileHandle(forWritingTo: URL(fileURLWithPath: path))
+            defer {
+                handle.closeFile()
+            }
+
+            handle.seekToEndOfFile()
+            handle.write(data)
+        } catch {
+            throw Error.writeFailed
+        }
     }
 
     /**
@@ -549,7 +559,11 @@ public final class File: FileSystem.Item, FileSystemIterable {
      *  - throws: `File.Error.writeFailed` if the string couldn't be encoded, or written to the file
      */
     public func append(string: String, encoding: String.Encoding = .utf8) throws {
-        // TODO: Implement
+        guard let data = string.data(using: encoding) else {
+            throw Error.writeFailed
+        }
+
+        try append(data: data)
     }
     
     /**

--- a/Tests/FilesTests/FilesTests.swift
+++ b/Tests/FilesTests/FilesTests.swift
@@ -474,6 +474,29 @@ class FilesTests: XCTestCase {
             try XCTAssertEqual(file.read(), "New content".data(using: .utf8))
         }
     }
+
+    func testAppendingDataToFile() {
+        performTest {
+            let file = try folder.createFile(named: "file")
+            let data = "Old content\n".data(using: .utf8)!
+            try file.write(data: data)
+
+            let newData = "I'm the appended content 💯\n".data(using: .utf8)!
+            try file.append(data: newData)
+            try XCTAssertEqual(file.read(), "Old content\nI'm the appended content 💯\n".data(using: .utf8))
+        }
+    }
+
+    func testAppendingStringToFile() {
+        performTest {
+            let file = try folder.createFile(named: "file")
+            try file.write(string: "Old content\n")
+
+            let newString = "I'm the appended content 💯\n"
+            try file.append(string: newString)
+            try XCTAssertEqual(file.read(), "Old content\nI'm the appended content 💯\n".data(using: .utf8))
+        }
+    }
     
     func testFileDescription() {
         performTest {
@@ -717,6 +740,8 @@ class FilesTests: XCTestCase {
         ("testDeletingNonExistingFileThrows", testDeletingNonExistingFileThrows),
         ("testWritingDataToFile", testWritingDataToFile),
         ("testWritingStringToFile", testWritingStringToFile),
+        ("testAppendingDataToFile", testAppendingDataToFile),
+        ("testAppendingStringToFile", testAppendingStringToFile),
         ("testFileDescription", testFileDescription),
         ("testFolderDescription", testFolderDescription),
         ("testMovingFolderContents", testMovingFolderContents),


### PR DESCRIPTION
Add appending data/string to files like `bash`'s `>>` operator.

```swift
func append(data: Data) throws
func append(string: String, encoding: String.Encoding = .utf8) throws
```
This should close #48.