### PR TITLE
Makes `FileSystemSequence` `CustomStringConvertible`

### DIFF
--- a/Sources/Files.swift
+++ b/Sources/Files.swift
@@ -850,7 +850,7 @@ public protocol FileSystemIterable {
  *  You don't create instances of this class yourself. Instead, you can access various sequences on a `Folder`, for example
  *  containing its files and subfolders. The sequence is lazily evaluated when you perform operations on it.
  */
-public class FileSystemSequence<T: FileSystem.Item>: Sequence where T: FileSystemIterable {
+public class FileSystemSequence<T: FileSystem.Item>: Sequence, CustomStringConvertible where T: FileSystemIterable {
     /// The number of items contained in this sequence. Accessing this causes the sequence to be evaluated.
     public var count: Int {
         var count = 0
@@ -895,6 +895,10 @@ public class FileSystemSequence<T: FileSystem.Item>: Sequence where T: FileSyste
     /// Move all the items in this sequence to a new folder. See `FileSystem.Item.move(to:)` for more info.
     public func move(to newParent: Folder) throws {
         try forEach { try $0.move(to: newParent) }
+    }
+
+    public var description: String {
+        return map { $0.description }.joined(separator: "\n")
     }
 }
 

--- a/Tests/FilesTests/FilesTests.swift
+++ b/Tests/FilesTests/FilesTests.swift
@@ -489,6 +489,22 @@ class FilesTests: XCTestCase {
         }
     }
 
+    func testFilesDescription() {
+        performTest {
+            let fileA = try folder.createFile(named: "fileA")
+            let fileB = try folder.createFile(named: "fileB")
+            XCTAssertEqual(folder.files.description, "\(fileA.description)\n\(fileB.description)")
+        }
+    }
+
+    func testSubfoldersDescription() {
+        performTest {
+            let folderA = try folder.createSubfolder(named: "folderA")
+            let folderB = try folder.createSubfolder(named: "folderB")
+            XCTAssertEqual(folder.subfolders.description, "\(folderA.description)\n\(folderB.description)")
+        }
+    }
+
     func testMovingFolderContents() {
         performTest {
             let parentFolder = try folder.createSubfolder(named: "parentA")
@@ -719,6 +735,8 @@ class FilesTests: XCTestCase {
         ("testWritingStringToFile", testWritingStringToFile),
         ("testFileDescription", testFileDescription),
         ("testFolderDescription", testFolderDescription),
+        ("testFilesDescription", testFilesDescription),
+        ("testSubfoldersDescription", testSubfoldersDescription),
         ("testMovingFolderContents", testMovingFolderContents),
         ("testMovingFolderHiddenContents", testMovingFolderHiddenContents),
         ("testAccessingHomeFolder", testAccessingHomeFolder),


### PR DESCRIPTION
Making `FileSystemSequence` `CustomStringConvertible` provides a better description, which is really helpful especially for debugging. For printing  a `folder`'s `subfolders` instead of:
```
<FileSystemSequence<Folder>: 0x102553ed0>
```
we will get:
```
Folder(name: folderA, path: path_to_folder/folderA/)
Folder(name: folderB, path: path_to_folder/folderB/)
```