### PR TITLE
Add support for Swift 4.0 & update CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,6 @@
-os: linux
+os:
+    - linux
+    - osx
 language: generic
 osx_image: xcode9
 sudo: required

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,10 @@ language: generic
 osx_image: xcode9
 sudo: required
 dist: trusty
+env:
+    - SWIFT_VERSION=4.0
+    - SWIFT_VERSION=4.1
 install:
-    - eval "$(curl -sL https://gist.githubusercontent.com/kylef/5c0475ff02b7c7671d2a/raw/9f442512a46d7a2af7b850d65a7e9bd31edfb09b/swiftenv-install.sh)"
+    - eval "$(curl -sL https://swiftenv.fuller.li/install.sh)"
 script:
     - swift test

--- a/Sources/Files.swift
+++ b/Sources/Files.swift
@@ -1112,6 +1112,12 @@ private extension ProcessInfo {
     }
 }
 
+#if os(Linux) && !(swift(>=4.1))
+private extension ObjCBool {
+    var boolValue: Bool { return Bool(self) }
+}
+#endif
+
 #if !os(Linux)
 extension FileSystem {
     /// A reference to the document folder used by this file system.


### PR DESCRIPTION
Hey John 👋 

The latest release broke `Files` for consumers & libraries that need Swift 4.0 support on Linux.

This PR:  
* Fixes #54 - Swift 4.0 support for Linux 
* Updates travis to run all combinations of Swift 4.0 / 4.1 - Linux & MacOS. Screenshot below.

<img width="741" alt="example_travis" src="https://user-images.githubusercontent.com/993745/38500358-1527a53c-3c02-11e8-88b9-c570c3ce257a.png">
