### PR TITLE
Folder contains file/subfolder

### DIFF
--- a/Sources/Files.swift
+++ b/Sources/Files.swift
@@ -685,6 +685,15 @@ public final class Folder: FileSystem.Item, FileSystemIterable {
     public func containsFile(named fileName: String) -> Bool {
         return (try? file(named: fileName)) != nil
     }
+
+    /**
+     *  Return whether this folder contains a given file
+     *
+     *  - parameter file: The file to check for
+     */
+    public func contains(_ file: File) -> Bool {
+        return files.contains(file)
+    }
     
     /**
      *  Return a folder with a given name that is contained in this folder
@@ -715,6 +724,15 @@ public final class Folder: FileSystem.Item, FileSystemIterable {
      */
     public func containsSubfolder(named folderName: String) -> Bool {
         return (try? subfolder(named: folderName)) != nil
+    }
+
+    /**
+     *  Return whether this folder contains a given subfolder
+     *
+     *  - parameter subfolder: The folder to check for
+     */
+    public func contains(_ subfolder: Folder) -> Bool {
+        return subfolders.contains(subfolder)
     }
     
     /**

--- a/Sources/Files.swift
+++ b/Sources/Files.swift
@@ -692,7 +692,7 @@ public final class Folder: FileSystem.Item, FileSystemIterable {
      *  - parameter file: The file to check for
      */
     public func contains(_ file: File) -> Bool {
-        return files.contains(file)
+        return containsFile(named: file.name)
     }
     
     /**
@@ -732,7 +732,7 @@ public final class Folder: FileSystem.Item, FileSystemIterable {
      *  - parameter subfolder: The folder to check for
      */
     public func contains(_ subfolder: Folder) -> Bool {
-        return subfolders.contains(subfolder)
+        return containsSubfolder(named: subfolder.name)
     }
     
     /**

--- a/Tests/FilesTests/FilesTests.swift
+++ b/Tests/FilesTests/FilesTests.swift
@@ -701,7 +701,8 @@ class FilesTests: XCTestCase {
 
     func testFolderContainsFile() {
         performTest {
-            let fileA = try FileSystem().temporaryFolder.createFile(named: UUID().uuidString)
+            let subfolder = try folder.createSubfolder(named: "subfolder")
+            let fileA = try subfolder.createFile(named: "A")
             XCTAssertFalse(folder.contains(fileA))
 
             let fileB = try folder.createFile(named: "B")
@@ -711,7 +712,8 @@ class FilesTests: XCTestCase {
 
     func testFolderContainsSubfolder() {
         performTest {
-            let subfolderA = try FileSystem().temporaryFolder.createSubfolder(named: UUID().uuidString)
+            let subfolder = try folder.createSubfolder(named: "subfolder")
+            let subfolderA = try subfolder.createSubfolder(named: "A")
             XCTAssertFalse(folder.contains(subfolderA))
 
             let subfolderB = try folder.createSubfolder(named: "B")

--- a/Tests/FilesTests/FilesTests.swift
+++ b/Tests/FilesTests/FilesTests.swift
@@ -698,6 +698,26 @@ class FilesTests: XCTestCase {
             try assert(subfolder.file(named: "file"), throwsError: File.PathError.invalid(file.path))
         }
     }
+
+    func testFolderContainsFile() {
+        performTest {
+            let fileA = try FileSystem().temporaryFolder.createFile(named: UUID().uuidString)
+            XCTAssertFalse(folder.contains(fileA))
+
+            let fileB = try folder.createFile(named: "B")
+            XCTAssertTrue(folder.contains(fileB))
+        }
+    }
+
+    func testFolderContainsSubfolder() {
+        performTest {
+            let subfolderA = try FileSystem().temporaryFolder.createSubfolder(named: UUID().uuidString)
+            XCTAssertFalse(folder.contains(subfolderA))
+
+            let subfolderB = try folder.createSubfolder(named: "B")
+            XCTAssertTrue(folder.contains(subfolderB))
+        }
+    }
     
     // MARK: - Utilities
     
@@ -775,7 +795,9 @@ class FilesTests: XCTestCase {
         ("testCreateFolderIfNeeded", testCreateFolderIfNeeded),
         ("testCreateSubfolderIfNeeded", testCreateSubfolderIfNeeded),
         ("testCreatingFileWithString", testCreatingFileWithString),
-        ("testUsingCustomFileManager", testUsingCustomFileManager)
+        ("testUsingCustomFileManager", testUsingCustomFileManager),
+        ("testFolderContainsFile", testFolderContainsFile),
+        ("testFolderContainsSubfolder", testFolderContainsSubfolder)
     ]
 }
 


### PR DESCRIPTION
This PR adds two methods to `Folder`:
1. `contains(_ file: File)`
2. `contains(_ subfolder: Folder)`

Resolves #60 