### PR TITLE
Only enable accessing Documents and Library folders on macOS

### DIFF
--- a/Sources/Files.swift
+++ b/Sources/Files.swift
@@ -1131,7 +1131,7 @@ private extension ObjCBool {
 }
 #endif
 
-#if !os(Linux)
+#if os(macOS)
 extension FileSystem {
     /// A reference to the document folder used by this file system.
     public var documentFolder: Folder? {

--- a/Tests/FilesTests/FilesTests.swift
+++ b/Tests/FilesTests/FilesTests.swift
@@ -803,14 +803,10 @@ class FilesTests: XCTestCase {
     ]
 }
 
-#if !os(Linux)
+#if os(macOS)
 extension FilesTests {
     func testAccessingDocumentFolder() {
-        #if os(tvOS)
-            XCTAssertNil(FileSystem().documentFolder, "Document folder should not be available on tvOS.")
-        #else
-            XCTAssertNotNil(FileSystem().documentFolder, "Document folder should be available.")
-        #endif
+        XCTAssertNotNil(FileSystem().documentFolder, "Document folder should be available.")
     }
     
     func testAccessingLibraryFolder() {


### PR DESCRIPTION
Apps on iOS-based operating systems don’t have access to these kinds of system resources.