### PR TITLE
FileSystemSequence: Add API for converting to recursive

### DIFF
--- a/Sources/Files.swift
+++ b/Sources/Files.swift
@@ -877,25 +877,35 @@ public class FileSystemSequence<T: FileSystem.Item>: Sequence, CustomStringConve
     }
 
     private let folder: Folder
-    private let recursive: Bool
+    private let isRecursive: Bool
     private let includeHidden: Bool
     private let fileManager: FileManager
 
     fileprivate init(folder: Folder, recursive: Bool, includeHidden: Bool, using fileManager: FileManager) {
         self.folder = folder
-        self.recursive = recursive
+        self.isRecursive = recursive
         self.includeHidden = includeHidden
         self.fileManager = fileManager
     }
     
     /// Create an iterator to use to iterate over the sequence
     public func makeIterator() -> FileSystemIterator<T> {
-        return FileSystemIterator(folder: folder, recursive: recursive, includeHidden: includeHidden, using: fileManager)
+        return FileSystemIterator(folder: folder, recursive: isRecursive, includeHidden: includeHidden, using: fileManager)
     }
     
     /// Move all the items in this sequence to a new folder. See `FileSystem.Item.move(to:)` for more info.
     public func move(to newParent: Folder) throws {
         try forEach { try $0.move(to: newParent) }
+    }
+
+    // Create a recursive version of this sequence
+    public var recursive: FileSystemSequence {
+        return FileSystemSequence(
+            folder: folder,
+            recursive: true,
+            includeHidden: includeHidden,
+            using: fileManager
+        )
     }
 
     public var description: String {

--- a/Tests/FilesTests/FilesTests.swift
+++ b/Tests/FilesTests/FilesTests.swift
@@ -414,6 +414,19 @@ class FilesTests: XCTestCase {
         }
     }
 
+    func testConvertingFileSequenceToRecursive() {
+        performTest {
+            try folder.createFile(named: "A")
+            try folder.createFile(named: "B")
+
+            let subfolder = try folder.createSubfolder(named: "1")
+            try subfolder.createFile(named: "1A")
+
+            let names = folder.files.recursive.names
+            XCTAssertEqual(names, ["A", "B", "1A"])
+        }
+    }
+
     func testModificationDate() {
         performTest {
             let subfolder = try folder.createSubfolder(named: "Folder")
@@ -792,6 +805,7 @@ class FilesTests: XCTestCase {
         ("testEnumeratingSubfoldersRecursively", testEnumeratingSubfoldersRecursively),
         ("testRenamingFoldersWhileEnumeratingSubfoldersRecursively", testRenamingFoldersWhileEnumeratingSubfoldersRecursively),
         ("testFirstAndLastInFileSequence", testFirstAndLastInFileSequence),
+        ("testConvertingFileSequenceToRecursive", testConvertingFileSequenceToRecursive),
         ("testModificationDate", testModificationDate),
         ("testParent", testParent),
         ("testRootFolderParentIsNil", testRootFolderParentIsNil),


### PR DESCRIPTION
This change introduces an API to directly convert a sequence of files into a recursive one, rather than having to use `Folder`’s `makeFileSequence(recursive: true)` method.