### PR TITLE
Enable referring to locations using the current folder’s path

### DIFF
--- a/Sources/Files.swift
+++ b/Sources/Files.swift
@@ -204,6 +204,8 @@ public final class Storage<LocationType: Location> {
     }
 
     private func validatePath() throws {
+        path = path.removingPrefix("./")
+
         switch LocationType.kind {
         case .file:
             guard !path.isEmpty else {
@@ -228,6 +230,10 @@ public final class Storage<LocationType: Location> {
             }
 
             path.replaceSubrange(..<parentReferenceRange.upperBound, with: parentPath)
+        }
+
+        if !path.hasPrefix("/") {
+            path = fileManager.currentDirectoryPath.appendingSuffixIfNeeded("/") + path
         }
 
         guard fileManager.locationExists(at: path, kind: LocationType.kind) else {
@@ -292,7 +298,7 @@ private extension Storage where LocationType == Folder {
     }
 
     func subfolder(at folderPath: String) throws -> Folder {
-        let folderPath = path + folderPath.removingPrefix("/")
+        let folderPath = path + folderPath.removingPrefix("/").removingPrefix("./")
         let storage = try Storage(path: folderPath, fileManager: fileManager)
         return Folder(storage: storage)
     }

--- a/Tests/FilesTests/FilesTests.swift
+++ b/Tests/FilesTests/FilesTests.swift
@@ -658,6 +658,32 @@ class FilesTests: XCTestCase {
             XCTAssertEqual(Folder.current, folder)
         }
     }
+
+    func testAccessingCurrentFolderWithRelativePath() {
+        performTest {
+            let folderA = try Folder(path: "./")
+            let folderB = try Folder.current.subfolder(at: "./")
+            XCTAssertEqual(folderA, folderB)
+            XCTAssertEqual(folderA, .current)
+        }
+    }
+
+    func testAccessingFileInCurrentFolderWithRelativePath() {
+        performTest {
+            let fileA = try Folder.current.createFile(named: "Test")
+            let fileB = try File(path: "./Test")
+            XCTAssertEqual(fileA, fileB)
+        }
+    }
+
+    func testAccessingParentFolderWithRelativePath() {
+        performTest {
+            let folderA = try Folder(path: "../")
+            let folderB = try Folder.current.subfolder(at: "../")
+            XCTAssertEqual(folderA, folderB)
+            XCTAssertEqual(folderA, Folder.current.parent)
+        }
+    }
     
     func testNameExcludingExtensionWithLongFileName() {
         performTest {
@@ -865,6 +891,9 @@ class FilesTests: XCTestCase {
         ("testMovingFolderHiddenContents", testMovingFolderHiddenContents),
         ("testAccessingHomeFolder", testAccessingHomeFolder),
         ("testAccessingCurrentWorkingDirectory", testAccessingCurrentWorkingDirectory),
+        ("testAccessingCurrentFolderWithRelativePath", testAccessingCurrentFolderWithRelativePath),
+        ("testAccessingFileInCurrentFolderWithRelativePath", testAccessingFileInCurrentFolderWithRelativePath),
+        ("testAccessingParentFolderWithRelativePath", testAccessingParentFolderWithRelativePath),
         ("testNameExcludingExtensionWithLongFileName", testNameExcludingExtensionWithLongFileName),
         ("testRelativePaths", testRelativePaths),
         ("testRelativePathIsAbsolutePathForNonParent", testRelativePathIsAbsolutePathForNonParent),


### PR DESCRIPTION
This change enables files and folders to be referred to using a path that starts with `./`. While this is redundant when using Files, since paths are assumed to start at the current folder, it’s useful when accepting file paths as input, and to better conform to system conventions.