### PR TITLE
Return copied filed/folder when calling copy()

### DIFF
--- a/Sources/Files.swift
+++ b/Sources/Files.swift
@@ -165,8 +165,12 @@ public extension Location {
     /// Copy the contents of this location to a given folder
     /// - parameter newParent: The folder to copy this item to.
     /// - throws: `LocationError` if the location couldn't be copied.
-    func copy(to folder: Folder) throws {
-        try storage.copy(to: folder.path + name)
+    /// - returns: The new, copied location.
+    @discardableResult
+    func copy(to folder: Folder) throws -> Self {
+        let path = folder.path + name
+        try storage.copy(to: path)
+        return try Self(path: path)
     }
 
     /// Delete this location. It will be permanently deleted. Use with caution.

--- a/Tests/FilesTests/FilesTests.swift
+++ b/Tests/FilesTests/FilesTests.swift
@@ -332,10 +332,11 @@ class FilesTests: XCTestCase {
             try file.write("content")
             
             let subfolder = try folder.createSubfolder(named: "folder")
-            try file.copy(to: subfolder)
+            let copiedFile = try file.copy(to: subfolder)
             try XCTAssertNotNil(folder.file(named: "A"))
             try XCTAssertNotNil(subfolder.file(named: "A"))
             try XCTAssertEqual(file.read(), subfolder.file(named: "A").read())
+            try XCTAssertEqual(copiedFile, subfolder.file(named: "A"))
             XCTAssertEqual(folder.files.count(), 1)
         }
     }
@@ -357,9 +358,10 @@ class FilesTests: XCTestCase {
             let copyingFolder = try folder.createSubfolder(named: "A")
             
             let subfolder = try folder.createSubfolder(named: "folder")
-            try copyingFolder.copy(to: subfolder)
+            let copiedFolder = try copyingFolder.copy(to: subfolder)
             XCTAssertTrue(folder.containsSubfolder(named: "A"))
             XCTAssertTrue(subfolder.containsSubfolder(named: "A"))
+            XCTAssertEqual(copiedFolder, try subfolder.subfolder(named: "A"))
             XCTAssertEqual(folder.subfolders.count(), 2)
             XCTAssertEqual(subfolder.subfolders.count(), 1)
         }


### PR DESCRIPTION
This patch fixes a regression that would cause a copied file or folder not to be returned as part of that operation. A test has also been added to make sure that this feature stays intact in the future.