### PR TITLE
Fix content not being considered when creating file if needed

### DIFF
--- a/Sources/Files.swift
+++ b/Sources/Files.swift
@@ -809,7 +809,7 @@ public extension Folder {
     @discardableResult
     func createFileIfNeeded(at path: String,
                             contents: @autoclosure () -> Data? = nil) throws -> File {
-        return try (try? file(at: path)) ?? createFile(at: path)
+        return try (try? file(at: path)) ?? createFile(at: path, contents: contents())
     }
 
     /// Create a new file with a given name. If a file with the given

--- a/Tests/FilesTests/FilesTests.swift
+++ b/Tests/FilesTests/FilesTests.swift
@@ -87,6 +87,22 @@ class FilesTests: XCTestCase {
         }
     }
 
+    func testCreatingFileIfNeededAtPath() {
+        performTest {
+            let path = "a/b/c.txt"
+
+            XCTAssertFalse(folder.containsFile(at: path))
+            var file = try folder.createFileIfNeeded(at: path, contents: Data("Hello".utf8))
+
+            XCTAssertTrue(folder.containsFile(at: path))
+            XCTAssertTrue(folder.containsSubfolder(named: "a"))
+            XCTAssertTrue(folder.containsSubfolder(at: "a/b"))
+
+            file = try folder.createFileIfNeeded(at: path, contents: Data())
+            XCTAssertEqual(try file.readAsString(), "Hello")
+        }
+    }
+
     func testDroppingLeadingSlashWhenCreatingFileAtPath() {
         performTest {
             let path = "/a/b/c.txt"


### PR DESCRIPTION
This patch fixes a bug that would cause a new file’s content to not be considered when using the `createFileIfNeeded` API.

Thanks to @maximkrouk for reporting this issue.