### PR TITLE
Adding simple temporary file and folder creation support

### DIFF
--- a/Sources/Files.swift
+++ b/Sources/Files.swift
@@ -862,6 +862,39 @@ public extension Folder {
     }
 }
 
+// MARK: Temporary files and folders
+
+public extension Folder {
+    /// Create a new uniquely-named file within this folder.
+    /// - Parameter prefix: (optional) prefix to add the temporary file name
+    /// - Parameter fileExtension: (optional) file extension (without the `.`) to use for the created file
+    /// - Parameter contents: (optional) the data to write to the file
+    /// - throws: `WriteError` if a new file couldn't be created.
+    func createTemporaryFile(prefix: String? = nil, fileExtension: String? = nil, contents: Data? = nil) throws -> File {
+        var tempFilename = ""
+        if let prefix = prefix {
+            tempFilename += prefix + "_"
+        }
+        tempFilename += ProcessInfo.processInfo.globallyUniqueString
+        if let fileExtension = fileExtension {
+            tempFilename += "." + fileExtension
+        }
+        return try self.createFile(at: tempFilename, contents: contents)
+    }
+
+    /// Create a new uniquely-named folder within this folder.
+    /// - Parameter prefix: (optional) prefix to add the temporary folder name
+    /// - throws: `WriteError` if a new folder couldn't be created.
+    func createTemporarySubfolder(prefix: String? = nil) throws -> Folder {
+        var tempFolderName = ""
+        if let prefix = prefix {
+            tempFolderName += prefix + "_"
+        }
+        tempFolderName += ProcessInfo.processInfo.globallyUniqueString
+        return try self.createSubfolder(named: tempFolderName)
+    }
+}
+
 #if os(macOS)
 public extension Folder {
     /// The current user's Documents folder

--- a/Tests/FilesTests/FilesTests.swift
+++ b/Tests/FilesTests/FilesTests.swift
@@ -819,6 +819,36 @@ class FilesTests: XCTestCase {
         Reason: stringEncodingFailed(\"Hello\")
         """)
     }
+
+    func testTemporaryFileFolderCreation() {
+        performTest {
+            // An empty temporary file in the Temporary files location
+            let tempFile1 = try Folder.temporary.createTemporaryFile(prefix: "TestFile", fileExtension: "fred")
+            XCTAssertTrue(Folder.temporary.contains(tempFile1))
+            XCTAssertTrue(tempFile1.name.starts(with: "TestFile_"))
+            XCTAssertEqual("fred", tempFile1.extension)
+            XCTAssertEqual(try tempFile1.read().count, 0)
+            try tempFile1.delete()
+
+            // Temporary file containing some data
+            let tempFile2 = try folder.createTemporaryFile(fileExtension: "extn", contents: Data("Hello".utf8))
+            XCTAssertTrue(folder.contains(tempFile2))
+            XCTAssertFalse(tempFile2.name.contains("_"))
+            XCTAssertEqual("extn", tempFile2.extension)
+            XCTAssertEqual(try tempFile2.readAsString(), "Hello")
+
+            // Simple folder without a prefix.
+            let tempFolder1 = try folder.createTemporarySubfolder()
+            XCTAssertTrue(folder.contains(tempFolder1))
+            XCTAssertFalse(tempFolder1.name.contains("_"))
+
+            // Folder with a prefix
+            let tempFolder2 = try Folder.temporary.createTemporarySubfolder(prefix: "TestFolder")
+            XCTAssertTrue(Folder.temporary.contains(tempFolder2))
+            XCTAssertTrue(tempFolder2.name.starts(with: "TestFolder_"))
+            try tempFolder2.delete()
+        }
+    }
     
     // MARK: - Utilities
     


### PR DESCRIPTION
Added ability to create a uniquely named temporary file or subfolder to a folder.

Uses globallyUniqueString as per NSHipster for temporary generation
https://nshipster.com/temporary-files/

createTemporaryFile
* Creates a temporary file within a folder with an optional prefix and extension
* Filename is of the format [prefix_]random_guid[.extension]

createTemporarySubfolder
* Creates a temporary subfolder within a folder with an optional prefix
* Filename is of the format [prefix_]random_guid