### PR TITLE
Fix nameExcludingExtension bug when there’s no extension

### DIFF
--- a/Sources/Files.swift
+++ b/Sources/Files.swift
@@ -74,7 +74,9 @@ public extension Location {
 
     /// The name of the location, excluding its `extension`.
     var nameExcludingExtension: String {
-        return name.split(separator: ".").dropLast().joined()
+        let components = name.split(separator: ".")
+        guard components.count > 1 else { return name }
+        return components.dropLast().joined()
     }
 
     /// The file extension of the item at the location.

--- a/Tests/FilesTests/FilesTests.swift
+++ b/Tests/FilesTests/FilesTests.swift
@@ -692,6 +692,16 @@ class FilesTests: XCTestCase {
         }
     }
 
+    func testNameExcludingExtensionWithoutExtension() {
+        performTest {
+            let file = try folder.createFile(named: "File")
+            let subfolder = try folder.createSubfolder(named: "Subfolder")
+
+            XCTAssertEqual(file.nameExcludingExtension, "File")
+            XCTAssertEqual(subfolder.nameExcludingExtension, "Subfolder")
+        }
+    }
+
     func testRelativePaths() {
         performTest {
             let file = try folder.createFile(named: "FileA")


### PR DESCRIPTION
Currently using `nameExcludingExtension` on a location that doesn’t actually have an extension results in an empty string, which this patch fixes. Now the full name is returned instead in those situations.