### PR TITLE
Add small fixes to make it easier to work with URLs

### DIFF
--- a/Sources/Files.swift
+++ b/Sources/Files.swift
@@ -204,7 +204,7 @@ public final class Storage<LocationType: Location> {
     private let fileManager: FileManager
 
     fileprivate init(path: String, fileManager: FileManager) throws {
-        self.path = path
+        self.path = path.replacingOccurrences(of: "file://", with: "")
         self.fileManager = fileManager
         try validatePath()
     }
@@ -974,10 +974,14 @@ public typealias ReadError = FilesError<ReadErrorReason>
 // MARK: - Private system extensions
 
 private extension FileManager {
+
     func locationExists(at path: String, kind: LocationKind) -> Bool {
         var isFolder: ObjCBool = false
 
-        guard fileExists(atPath: path, isDirectory: &isFolder) else {
+        guard let decoded = path.removingPercentEncoding else {
+            return false
+        }
+        guard fileExists(atPath: decoded, isDirectory: &isFolder) else {
             return false
         }
 


### PR DESCRIPTION
I'm using the solution to encapsulate the Foundation API's for Files and Folders selected by the user in NSOpenPanel. In that scenario, the result of the user input is received as URL instead of String. Before creating Files or Folders objects I always need to remove the protocol of the URI (file://) and, in the case of files and folders with spaces in the name, I need to remove the Percent Encoding.
 
Considering that the Domain for this solution is Files and Folders, I understand that these tasks could be implemented inside the Solution instead of outside. Because of that I added one fix to the Storage Initialization ( Clean the protocol of the URI in case of file:// ) and one fix to the folder evaluation (Remove percentage encoding before calling the ObjC method). All of these fixes are extensions in the sense that they didn't changed any interface and, if the explained cases are not present, they will not create any effect.

Tests are working on local:
Test Suite 'FilesTests' passed at 2020-01-07 17:51:19.715.
	 Executed 64 tests, with 0 failures (0 unexpected) in 0.166 (0.168) seconds
Test Suite 'FilesPackageTests.xctest' passed at 2020-01-07 17:51:19.715.
	 Executed 64 tests, with 0 failures (0 unexpected) in 0.166 (0.168) seconds
Test Suite 'All tests' passed at 2020-01-07 17:51:19.715.
	 Executed 64 tests, with 0 failures (0 unexpected) in 0.166 (0.169) seconds

- Add some small fixes to make the solution more easy to use with URL.relativeString and URL.absoluteString;
- Add Suport to encoded URI's, this helps when passing URL parameters with folders and files where the name contains spaces.

Committer: Gustavo Tavares <grstavares@gmail.com>
Your branch is up to date with 'origin/master'.

Changes to be committed:
	modified:   Sources/Files.swift