### PR TITLE
Fix typo in files error description

### DIFF
--- a/Sources/Files.swift
+++ b/Sources/Files.swift
@@ -916,7 +916,7 @@ public struct FilesError<Reason>: Error {
 extension FilesError: CustomStringConvertible {
     public var description: String {
         return """
-        Files encounted an error at '\(path)'.
+        Files encountered an error at '\(path)'.
         Reason: \(reason)
         """
     }

--- a/Tests/FilesTests/FilesTests.swift
+++ b/Tests/FilesTests/FilesTests.swift
@@ -815,7 +815,7 @@ class FilesTests: XCTestCase {
         )
 
         XCTAssertEqual(missingError.description, """
-        Files encounted an error at '/some/path'.
+        Files encountered an error at '/some/path'.
         Reason: missing
         """)
 
@@ -825,7 +825,7 @@ class FilesTests: XCTestCase {
         )
 
         XCTAssertEqual(encodingError.description, """
-        Files encounted an error at '/some/path'.
+        Files encountered an error at '/some/path'.
         Reason: stringEncodingFailed(\"Hello\")
         """)
     }


### PR DESCRIPTION
Hello John and thanks for this great library! 👋 

I've recently started to use this package with the new [Swift Argument Parser](https://github.com/apple/swift-argument-parser) and it works flawlessly.

The thing is that is that every time wrong arguments are passed and error is thrown in Files, it is printed out with a typo like this:

```
Error: Files encounted an error at '/some/path'.
Reason: missing
Program ended with exit code: 1
```

*TLDR: I fixed a typo in the error which you are getting a lot during development/using the library.*