### PR TITLE
Folder: Add API for resolving search paths

### DIFF
--- a/Sources/Files.swift
+++ b/Sources/Files.swift
@@ -688,31 +688,6 @@ public extension Folder {
         return try! Folder(path: NSTemporaryDirectory())
     }
 
-    /// Resolve a folder that matches a search path within a given domain.
-    /// - parameter searchPath: The directory path to search for.
-    /// - parameter domain: The domain to search in.
-    /// - parameter fileManager: Which file manager to search using.
-    /// - throws: `LocationError` if no folder could be resolved.
-    static func matching(
-        _ searchPath: FileManager.SearchPathDirectory,
-        in domain: FileManager.SearchPathDomainMask = .userDomainMask,
-        resolvedBy fileManager: FileManager = .default
-    ) throws -> Folder {
-        let urls = fileManager.urls(for: searchPath, in: domain)
-
-        guard let match = urls.first else {
-            throw LocationError(
-                path: "",
-                reason: .unresolvedSearchPath(searchPath, domain: domain)
-            )
-        }
-
-        return try Folder(storage: Storage(
-            path: match.relativePath,
-            fileManager: fileManager
-        ))
-    }
-
     /// A sequence containing all of this folder's subfolders. Initially
     /// non-recursive, use `recursive` on the returned sequence to change that.
     var subfolders: ChildSequence<Folder> {
@@ -901,6 +876,35 @@ public extension Folder {
         try folders.delete()
     }
 }
+
+#if os(iOS) || os(tvOS) || os(macOS)
+public extension Folder {
+    /// Resolve a folder that matches a search path within a given domain.
+    /// - parameter searchPath: The directory path to search for.
+    /// - parameter domain: The domain to search in.
+    /// - parameter fileManager: Which file manager to search using.
+    /// - throws: `LocationError` if no folder could be resolved.
+    static func matching(
+        _ searchPath: FileManager.SearchPathDirectory,
+        in domain: FileManager.SearchPathDomainMask = .userDomainMask,
+        resolvedBy fileManager: FileManager = .default
+    ) throws -> Folder {
+        let urls = fileManager.urls(for: searchPath, in: domain)
+
+        guard let match = urls.first else {
+            throw LocationError(
+                path: "",
+                reason: .unresolvedSearchPath(searchPath, domain: domain)
+            )
+        }
+
+        return try Folder(storage: Storage(
+            path: match.relativePath,
+            fileManager: fileManager
+        ))
+    }
+}
+#endif
 
 #if os(macOS)
 public extension Folder {

--- a/Sources/Files.swift
+++ b/Sources/Files.swift
@@ -688,7 +688,6 @@ public extension Folder {
         return try! Folder(path: NSTemporaryDirectory())
     }
 
-
     /// Resolve a folder that matches a search path within a given domain.
     /// - parameter searchPath: The directory path to search for.
     /// - parameter domain: The domain to search in.

--- a/Tests/FilesTests/FilesTests.swift
+++ b/Tests/FilesTests/FilesTests.swift
@@ -684,37 +684,6 @@ class FilesTests: XCTestCase {
             XCTAssertEqual(Folder.current, folder)
         }
     }
-
-    func testResolvingFolderMatchingSearchPath() {
-        performTest {
-            // Real file I/O
-            XCTAssertNotNil(try Folder.matching(.cachesDirectory))
-            XCTAssertNotNil(try Folder.matching(.libraryDirectory))
-
-            // Mocked file I/O
-            final class FileManagerMock: FileManager {
-                var target: Folder?
-
-                override func urls(
-                    for directory: FileManager.SearchPathDirectory,
-                    in domainMask: FileManager.SearchPathDomainMask
-                ) -> [URL] {
-                    return target.map { [$0.url] } ?? []
-                }
-            }
-
-            let target = try folder.createSubfolder(named: "Target")
-
-            let fileManager = FileManagerMock()
-            fileManager.target = target
-
-            let resolved = try Folder.matching(.documentDirectory,
-                resolvedBy: fileManager
-            )
-
-            XCTAssertEqual(resolved, target)
-        }
-    }
     
     func testNameExcludingExtensionWithLongFileName() {
         performTest {
@@ -933,7 +902,6 @@ class FilesTests: XCTestCase {
         ("testMovingFolderHiddenContents", testMovingFolderHiddenContents),
         ("testAccessingHomeFolder", testAccessingHomeFolder),
         ("testAccessingCurrentWorkingDirectory", testAccessingCurrentWorkingDirectory),
-        ("testResolvingFolderMatchingSearchPath", testResolvingFolderMatchingSearchPath),
         ("testNameExcludingExtensionWithLongFileName", testNameExcludingExtensionWithLongFileName),
         ("testRelativePaths", testRelativePaths),
         ("testRelativePathIsAbsolutePathForNonParent", testRelativePathIsAbsolutePathForNonParent),
@@ -947,6 +915,41 @@ class FilesTests: XCTestCase {
         ("testErrorDescriptions", testErrorDescriptions)
     ]
 }
+
+#if os(iOS) || os(tvOS) || os(macOS)
+extension FilesTests {
+    func testResolvingFolderMatchingSearchPath() {
+        performTest {
+            // Real file I/O
+            XCTAssertNotNil(try Folder.matching(.cachesDirectory))
+            XCTAssertNotNil(try Folder.matching(.libraryDirectory))
+
+            // Mocked file I/O
+            final class FileManagerMock: FileManager {
+                var target: Folder?
+
+                override func urls(
+                    for directory: FileManager.SearchPathDirectory,
+                    in domainMask: FileManager.SearchPathDomainMask
+                ) -> [URL] {
+                    return target.map { [$0.url] } ?? []
+                }
+            }
+
+            let target = try folder.createSubfolder(named: "Target")
+
+            let fileManager = FileManagerMock()
+            fileManager.target = target
+
+            let resolved = try Folder.matching(.documentDirectory,
+                resolvedBy: fileManager
+            )
+
+            XCTAssertEqual(resolved, target)
+        }
+    }
+}
+#endif
 
 #if os(macOS)
 extension FilesTests {

--- a/Tests/FilesTests/FilesTests.swift
+++ b/Tests/FilesTests/FilesTests.swift
@@ -684,6 +684,37 @@ class FilesTests: XCTestCase {
             XCTAssertEqual(Folder.current, folder)
         }
     }
+
+    func testResolvingFolderMatchingSearchPath() {
+        performTest {
+            // Real file I/O
+            XCTAssertNotNil(try Folder.matching(.cachesDirectory))
+            XCTAssertNotNil(try Folder.matching(.libraryDirectory))
+
+            // Mocked file I/O
+            final class FileManagerMock: FileManager {
+                var target: Folder?
+
+                override func urls(
+                    for directory: FileManager.SearchPathDirectory,
+                    in domainMask: FileManager.SearchPathDomainMask
+                ) -> [URL] {
+                    return target.map { [$0.url] } ?? []
+                }
+            }
+
+            let target = try folder.createSubfolder(named: "Target")
+
+            let fileManager = FileManagerMock()
+            fileManager.target = target
+
+            let resolved = try Folder.matching(.documentDirectory,
+                resolvedBy: fileManager
+            )
+
+            XCTAssertEqual(resolved, target)
+        }
+    }
     
     func testNameExcludingExtensionWithLongFileName() {
         performTest {
@@ -902,6 +933,7 @@ class FilesTests: XCTestCase {
         ("testMovingFolderHiddenContents", testMovingFolderHiddenContents),
         ("testAccessingHomeFolder", testAccessingHomeFolder),
         ("testAccessingCurrentWorkingDirectory", testAccessingCurrentWorkingDirectory),
+        ("testResolvingFolderMatchingSearchPath", testResolvingFolderMatchingSearchPath),
         ("testNameExcludingExtensionWithLongFileName", testNameExcludingExtensionWithLongFileName),
         ("testRelativePaths", testRelativePaths),
         ("testRelativePathIsAbsolutePathForNonParent", testRelativePathIsAbsolutePathForNonParent),


### PR DESCRIPTION
This change adds a public API for resolving a folder for a given search path within a domain. This new API is now also used internally to resolve the current user’s “Documents” and “Library” folders.