### PR TITLE
Expose more standard Folders on iOS/tvOS

### DIFF
--- a/Sources/Files.swift
+++ b/Sources/Files.swift
@@ -903,11 +903,7 @@ public extension Folder {
             fileManager: fileManager
         ))
     }
-}
-#endif
 
-#if os(macOS)
-public extension Folder {
     /// The current user's Documents folder
     static var documents: Folder? {
         return try? .matching(.documentDirectory)

--- a/Tests/FilesTests/FilesTests.swift
+++ b/Tests/FilesTests/FilesTests.swift
@@ -948,12 +948,13 @@ extension FilesTests {
             XCTAssertEqual(resolved, target)
         }
     }
-}
-#endif
 
-#if os(macOS)
-extension FilesTests {
     func testAccessingDocumentFolder() {
+        #if !os(macOS)
+        // iOS and tvOS are not guaranteed to have a documents directory
+        _ = try? Folder.home.createSubfolder(at: "Documents")
+        #endif
+
         XCTAssertNotNil(Folder.documents, "Document folder should be available.")
     }
     


### PR DESCRIPTION
More Folder API for iOS and tvOS
- `Folder.documents` used for data that should be backed up by the OS
- `Folder.library` maps to `/Library` with whatever is in there 😝