### PR TITLE
Make the `attributes` property on Storage public

### DIFF
--- a/Sources/Files.swift
+++ b/Sources/Files.swift
@@ -240,13 +240,14 @@ public final class Storage<LocationType: Location> {
             throw LocationError(path: path, reason: .missing)
         }
     }
+
+    /// File attributes for this filesystem location.
+    public var attributes: [FileAttributeKey : Any] {
+        return (try? fileManager.attributesOfItem(atPath: path)) ?? [:]
+    }
 }
 
 fileprivate extension Storage {
-    var attributes: [FileAttributeKey : Any] {
-        return (try? fileManager.attributesOfItem(atPath: path)) ?? [:]
-    }
-
     func makeParentPath(for path: String) -> String? {
         guard path != "/" else { return nil }
         let url = URL(fileURLWithPath: path)


### PR DESCRIPTION
I could really use access to the attributes of each location to retrieve things like file sizes and icon previews on macOS. 

This change feels nicely contained behind the storage type, but would allow extensions to expose specific properties on the `File`/`Folder` types down the road if anyone wanted to do that.