### PR TITLE
Add `isEmpty` method for `Folder`

### DIFF
--- a/Sources/Files.swift
+++ b/Sources/Files.swift
@@ -875,6 +875,18 @@ public extension Folder {
         folders.includeHidden = includeHidden
         try folders.delete()
     }
+    
+    func isEmpty(includingHidden includeHidden: Bool = false) -> Bool {
+        var files = self.files
+        files.includeHidden = includeHidden
+        if files.first != nil {
+            return false
+        }
+
+        var folders = subfolders
+        folders.includeHidden = includeHidden
+        return folders.first == nil
+    }
 }
 
 #if os(iOS) || os(tvOS) || os(macOS)

--- a/Sources/Files.swift
+++ b/Sources/Files.swift
@@ -879,6 +879,7 @@ public extension Folder {
     func isEmpty(includingHidden includeHidden: Bool = false) -> Bool {
         var files = self.files
         files.includeHidden = includeHidden
+        
         if files.first != nil {
             return false
         }

--- a/Tests/FilesTests/FilesTests.swift
+++ b/Tests/FilesTests/FilesTests.swift
@@ -328,6 +328,26 @@ class FilesTests: XCTestCase {
         }
     }
     
+    func testCheckingEmptyFolders() {
+        performTest {
+            let emptySubfolder = try folder.createSubfolder(named: "1")
+            XCTAssertTrue(emptySubfolder.isEmpty())
+            
+            let subfolderWithFile = try folder.createSubfolder(named: "2")
+            try subfolderWithFile.createFile(named: "A")
+            XCTAssertFalse(subfolderWithFile.isEmpty())
+            
+            let subfolderWithHiddenFile = try folder.createSubfolder(named: "3")
+            try subfolderWithHiddenFile.createFile(named: ".B")
+            XCTAssertTrue(subfolderWithHiddenFile.isEmpty())
+            XCTAssertFalse(subfolderWithHiddenFile.isEmpty(includingHidden: true))
+            
+            let subfolderWithFolder = try folder.createSubfolder(named: "3")
+            try subfolderWithFolder.createSubfolder(named: "4")
+            XCTAssertFalse(subfolderWithFile.isEmpty())
+        }
+    }
+
     func testMovingFiles() {
         performTest {
             try folder.createFile(named: "A")
@@ -873,6 +893,7 @@ class FilesTests: XCTestCase {
         ("testAccessingSubfolderByPath", testAccessingSubfolderByPath),
         ("testEmptyingFolder", testEmptyingFolder),
         ("testEmptyingFolderWithHiddenFiles", testEmptyingFolderWithHiddenFiles),
+        ("testCheckingEmptyFolders", testCheckingEmptyFolders),
         ("testMovingFiles", testMovingFiles),
         ("testCopyingFiles", testCopyingFiles),
         ("testCopyingFolders", testCopyingFolders),


### PR DESCRIPTION
This change adds a possibility to check if a folder is empty, including hidden files.