### PR TITLE
Extend build-in support for Documents and Library folders to more platforms

### DIFF
--- a/Sources/Files.swift
+++ b/Sources/Files.swift
@@ -903,11 +903,7 @@ public extension Folder {
             fileManager: fileManager
         ))
     }
-}
-#endif
 
-#if os(macOS)
-public extension Folder {
     /// The current user's Documents folder
     static var documents: Folder? {
         return try? .matching(.documentDirectory)

--- a/Tests/FilesTests/FilesTests.swift
+++ b/Tests/FilesTests/FilesTests.swift
@@ -916,8 +916,20 @@ class FilesTests: XCTestCase {
     ]
 }
 
+#if os(macOS)
+extension FilesTests {
+    func testAccessingDocumentsFolder() {
+        XCTAssertNotNil(Folder.documents, "Documents folder should be available.")
+    }
+}
+#endif
+
 #if os(iOS) || os(tvOS) || os(macOS)
 extension FilesTests {
+    func testAccessingLibraryFolder() {
+        XCTAssertNotNil(Folder.library, "Library folder should be available.")
+    }
+
     func testResolvingFolderMatchingSearchPath() {
         performTest {
             // Real file I/O
@@ -947,18 +959,6 @@ extension FilesTests {
 
             XCTAssertEqual(resolved, target)
         }
-    }
-}
-#endif
-
-#if os(macOS)
-extension FilesTests {
-    func testAccessingDocumentFolder() {
-        XCTAssertNotNil(Folder.documents, "Document folder should be available.")
-    }
-    
-    func testAccessingLibraryFolder() {
-        XCTAssertNotNil(Folder.library, "Library folder should be available.")
     }
 }
 #endif


### PR DESCRIPTION
This change makes the built-in APIs for retrieving the system-provided `Documents` and `Library` folders available on iOS and tvOS, as well as macOS (which was already supported).