### PR TITLE
Location conforms to ArgumentParser. ExpressibleByArgument

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -2,6 +2,15 @@
   "object": {
     "pins": [
       {
+        "package": "AirbnbSwift",
+        "repositoryURL": "https://github.com/airbnb/swift",
+        "state": {
+          "branch": null,
+          "revision": "1bf961396cc9c690db37936bfbdc8b5f29e844af",
+          "version": "1.0.1"
+        }
+      },
+      {
         "package": "swift-argument-parser",
         "repositoryURL": "https://github.com/apple/swift-argument-parser.git",
         "state": {

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,0 +1,16 @@
+{
+  "object": {
+    "pins": [
+      {
+        "package": "swift-argument-parser",
+        "repositoryURL": "https://github.com/apple/swift-argument-parser.git",
+        "state": {
+          "branch": null,
+          "revision": "9f39744e025c7d377987f30b03770805dcb0bcd1",
+          "version": "1.1.4"
+        }
+      }
+    ]
+  },
+  "version": 1
+}

--- a/Package.resolved
+++ b/Package.resolved
@@ -2,15 +2,6 @@
   "object": {
     "pins": [
       {
-        "package": "AirbnbSwift",
-        "repositoryURL": "https://github.com/airbnb/swift",
-        "state": {
-          "branch": null,
-          "revision": "1bf961396cc9c690db37936bfbdc8b5f29e844af",
-          "version": "1.0.1"
-        }
-      },
-      {
         "package": "swift-argument-parser",
         "repositoryURL": "https://github.com/apple/swift-argument-parser.git",
         "state": {

--- a/Package.swift
+++ b/Package.swift
@@ -13,9 +13,11 @@ let package = Package(
     products: [
         .library(name: "Files", targets: ["Files"])
     ],
+    dependencies: [ .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.1.4")],
     targets: [
         .target(
             name: "Files",
+            dependencies: [.product(name: "ArgumentParser", package: "swift-argument-parser")],
             path: "Sources"
         ),
         .testTarget(

--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,6 @@ let package = Package(
   ],
   dependencies: [
     .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.1.4"),
-    .package(url: "https://github.com/airbnb/swift", from: "1.0.0"),
   ],
   targets: [
     .target(

--- a/Package.swift
+++ b/Package.swift
@@ -1,28 +1,26 @@
 // swift-tools-version:5.0
 
-/**
- *  Files
- *  Copyright (c) John Sundell 2017
- *  Licensed under the MIT license. See LICENSE file.
- */
+///  Files
+///  Copyright (c) John Sundell 2017
+///  Licensed under the MIT license. See LICENSE file.
 
 import PackageDescription
 
 let package = Package(
-    name: "Files",
-    products: [
-        .library(name: "Files", targets: ["Files"])
-    ],
-    dependencies: [ .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.1.4")],
-    targets: [
-        .target(
-            name: "Files",
-            dependencies: [.product(name: "ArgumentParser", package: "swift-argument-parser")],
-            path: "Sources"
-        ),
-        .testTarget(
-            name: "FilesTests",
-            dependencies: ["Files"]
-        )
-    ]
-)
+  name: "Files",
+  products: [
+    .library(name: "Files", targets: ["Files"]),
+  ],
+  dependencies: [
+    .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.1.4"),
+    .package(url: "https://github.com/airbnb/swift", from: "1.0.0"),
+  ],
+  targets: [
+    .target(
+      name: "Files",
+      dependencies: [.product(name: "ArgumentParser", package: "swift-argument-parser")],
+      path: "Sources"),
+    .testTarget(
+      name: "FilesTests",
+      dependencies: ["Files"]),
+  ])

--- a/Sources/Files.swift
+++ b/Sources/Files.swift
@@ -1,198 +1,199 @@
-/**
- *  Files
- *
- *  Copyright (c) 2017-2019 John Sundell. Licensed under the MIT license, as follows:
- *
- *  Permission is hereby granted, free of charge, to any person obtaining a copy
- *  of this software and associated documentation files (the "Software"), to deal
- *  in the Software without restriction, including without limitation the rights
- *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- *  copies of the Software, and to permit persons to whom the Software is
- *  furnished to do so, subject to the following conditions:
- *
- *  The above copyright notice and this permission notice shall be included in all
- *  copies or substantial portions of the Software.
- *
- *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- *  SOFTWARE.
- */
+///  Files
+/// 
+///  Copyright (c) 2017-2019 John Sundell. Licensed under the MIT license, as follows:
+/// 
+///  Permission is hereby granted, free of charge, to any person obtaining a copy
+///  of this software and associated documentation files (the "Software"), to deal
+///  in the Software without restriction, including without limitation the rights
+///  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+///  copies of the Software, and to permit persons to whom the Software is
+///  furnished to do so, subject to the following conditions:
+/// 
+///  The above copyright notice and this permission notice shall be included in all
+///  copies or substantial portions of the Software.
+/// 
+///  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+///  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+///  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+///  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+///  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+///  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+///  SOFTWARE.
 
-import Foundation
 import ArgumentParser
+import Foundation
 
-// MARK: - Locations
+// MARK: - LocationKind
 
 /// Enum describing various kinds of locations that can be found on a file system.
 public enum LocationKind {
-    /// A file can be found at the location.
-    case file
-    /// A folder can be found at the location.
-    case folder
+  /// A file can be found at the location.
+  case file
+  /// A folder can be found at the location.
+  case folder
 }
+
+// MARK: - Location
 
 /// Protocol adopted by types that represent locations on a file system.
 public protocol Location: Equatable, CustomStringConvertible, ExpressibleByArgument, Codable {
-    /// The kind of location that is being represented (see `LocationKind`).
-    static var kind: LocationKind { get }
-    /// The underlying storage for the item at the represented location.
-    /// You don't interact with this object as part of the public API.
-    var storage: Storage<Self> { get }
-    /// Initialize an instance of this location with its underlying storage.
-    /// You don't call this initializer as part of the public API, instead
-    /// use `init(path:)` on either `File` or `Folder`.
-    init(storage: Storage<Self>)
+  /// The kind of location that is being represented (see `LocationKind`).
+  static var kind: LocationKind { get }
+  /// The underlying storage for the item at the represented location.
+  /// You don't interact with this object as part of the public API.
+  var storage: Storage<Self> { get }
+  /// Initialize an instance of this location with its underlying storage.
+  /// You don't call this initializer as part of the public API, instead
+  /// use `init(path:)` on either `File` or `Folder`.
+  init(storage: Storage<Self>)
 }
 
-public extension Location {
-    static func ==(lhs: Self, rhs: Self) -> Bool {
-        return lhs.storage.path == rhs.storage.path
+extension Location {
+
+  // MARK: Lifecycle
+
+  /// Initialize an instance of an existing location at a given path.
+  /// - parameter path: The absolute path of the location.
+  /// - throws: `LocationError` if the item couldn't be found.
+  public init(path: String) throws {
+    try self.init(storage: Storage(
+      path: path,
+      fileManager: .default))
+  }
+
+  // MARK: Public
+
+  public var description: String {
+    let typeName = String(describing: type(of: self))
+    return "\(typeName)(name: \(name), path: \(path))"
+  }
+
+  /// The path of this location, relative to the root of the file system.
+  public var path: String {
+    return storage.path
+  }
+
+  /// A URL representation of the location's `path`.
+  public var url: URL {
+    return URL(fileURLWithPath: path)
+  }
+
+  /// The name of the location, including any `extension`.
+  public var name: String {
+    return url.pathComponents.last!
+  }
+
+  /// The name of the location, excluding its `extension`.
+  public var nameExcludingExtension: String {
+    let components = name.split(separator: ".")
+    guard components.count > 1 else { return name }
+    return components.dropLast().joined()
+  }
+
+  /// The file extension of the item at the location.
+  public var `extension`: String? {
+    let components = name.split(separator: ".")
+    guard components.count > 1 else { return nil }
+    return String(components.last!)
+  }
+
+  /// The parent folder that this location is contained within.
+  public var parent: Folder? {
+    return storage.makeParentPath(for: path).flatMap {
+      try? Folder(path: $0)
+    }
+  }
+
+  /// The date when the item at this location was created.
+  /// Only returns `nil` in case the item has now been deleted.
+  public var creationDate: Date? {
+    return storage.attributes[.creationDate] as? Date
+  }
+
+  /// The date when the item at this location was last modified.
+  /// Only returns `nil` in case the item has now been deleted.
+  public var modificationDate: Date? {
+    return storage.attributes[.modificationDate] as? Date
+  }
+
+  public static func ==(lhs: Self, rhs: Self) -> Bool {
+    return lhs.storage.path == rhs.storage.path
+  }
+
+  /// Return the path of this location relative to a parent folder.
+  /// For example, if this item is located at `/users/john/documents`
+  /// and `/users/john` is passed, then `documents` is returned. If the
+  /// passed folder isn't an ancestor of this item, then the item's
+  /// absolute `path` is returned instead.
+  /// - parameter folder: The folder to compare this item's path against.
+  public func path(relativeTo folder: Folder) -> String {
+    guard path.hasPrefix(folder.path) else {
+      return path
     }
 
-    var description: String {
-        let typeName = String(describing: type(of: self))
-        return "\(typeName)(name: \(name), path: \(path))"
+    let index = path.index(path.startIndex, offsetBy: folder.path.count)
+    return String(path[index...]).removingSuffix("/")
+  }
+
+  /// Rename this location, keeping its existing `extension` by default.
+  /// - parameter newName: The new name to give the location.
+  /// - parameter keepExtension: Whether the location's `extension` should
+  ///   remain unmodified (default: `true`).
+  /// - throws: `LocationError` if the item couldn't be renamed.
+  public func rename(to newName: String, keepExtension: Bool = true) throws {
+    guard let parent = parent else {
+      throw LocationError(path: path, reason: .cannotRenameRoot)
     }
 
-    /// The path of this location, relative to the root of the file system.
-    var path: String {
-        return storage.path
+    var newName = newName
+
+    if keepExtension {
+      `extension`.map {
+        newName = newName.appendingSuffixIfNeeded(".\($0)")
+      }
     }
 
-    /// A URL representation of the location's `path`.
-    var url: URL {
-        return URL(fileURLWithPath: path)
-    }
+    try storage.move(
+      to: parent.path + newName,
+      errorReasonProvider: LocationErrorReason.renameFailed)
+  }
 
-    /// The name of the location, including any `extension`.
-    var name: String {
-        return url.pathComponents.last!
-    }
+  /// Move this location to a new parent folder
+  /// - parameter newParent: The folder to move this item to.
+  /// - throws: `LocationError` if the location couldn't be moved.
+  public func move(to newParent: Folder) throws {
+    try storage.move(
+      to: newParent.path + name,
+      errorReasonProvider: LocationErrorReason.moveFailed)
+  }
 
-    /// The name of the location, excluding its `extension`.
-    var nameExcludingExtension: String {
-        let components = name.split(separator: ".")
-        guard components.count > 1 else { return name }
-        return components.dropLast().joined()
-    }
+  /// Copy the contents of this location to a given folder
+  /// - parameter newParent: The folder to copy this item to.
+  /// - throws: `LocationError` if the location couldn't be copied.
+  /// - returns: The new, copied location.
+  @discardableResult
+  public func copy(to folder: Folder) throws -> Self {
+    let path = folder.path + name
+    try storage.copy(to: path)
+    return try Self(path: path)
+  }
 
-    /// The file extension of the item at the location.
-    var `extension`: String? {
-        let components = name.split(separator: ".")
-        guard components.count > 1 else { return nil }
-        return String(components.last!)
-    }
+  /// Delete this location. It will be permanently deleted. Use with caution.
+  /// - throws: `LocationError` if the item couldn't be deleted.
+  public func delete() throws {
+    try storage.delete()
+  }
 
-    /// The parent folder that this location is contained within.
-    var parent: Folder? {
-        return storage.makeParentPath(for: path).flatMap {
-            try? Folder(path: $0)
-        }
-    }
-
-    /// The date when the item at this location was created.
-    /// Only returns `nil` in case the item has now been deleted.
-    var creationDate: Date? {
-        return storage.attributes[.creationDate] as? Date
-    }
-
-    /// The date when the item at this location was last modified.
-    /// Only returns `nil` in case the item has now been deleted.
-    var modificationDate: Date? {
-        return storage.attributes[.modificationDate] as? Date
-    }
-
-    /// Initialize an instance of an existing location at a given path.
-    /// - parameter path: The absolute path of the location.
-    /// - throws: `LocationError` if the item couldn't be found.
-    init(path: String) throws {
-        try self.init(storage: Storage(
-            path: path,
-            fileManager: .default
-        ))
-    }
-
-    /// Return the path of this location relative to a parent folder.
-    /// For example, if this item is located at `/users/john/documents`
-    /// and `/users/john` is passed, then `documents` is returned. If the
-    /// passed folder isn't an ancestor of this item, then the item's
-    /// absolute `path` is returned instead.
-    /// - parameter folder: The folder to compare this item's path against.
-    func path(relativeTo folder: Folder) -> String {
-        guard path.hasPrefix(folder.path) else {
-            return path
-        }
-
-        let index = path.index(path.startIndex, offsetBy: folder.path.count)
-        return String(path[index...]).removingSuffix("/")
-    }
-
-    /// Rename this location, keeping its existing `extension` by default.
-    /// - parameter newName: The new name to give the location.
-    /// - parameter keepExtension: Whether the location's `extension` should
-    ///   remain unmodified (default: `true`).
-    /// - throws: `LocationError` if the item couldn't be renamed.
-    func rename(to newName: String, keepExtension: Bool = true) throws {
-        guard let parent = parent else {
-            throw LocationError(path: path, reason: .cannotRenameRoot)
-        }
-
-        var newName = newName
-
-        if keepExtension {
-            `extension`.map {
-                newName = newName.appendingSuffixIfNeeded(".\($0)")
-            }
-        }
-
-        try storage.move(
-            to: parent.path + newName,
-            errorReasonProvider: LocationErrorReason.renameFailed
-        )
-    }
-
-    /// Move this location to a new parent folder
-    /// - parameter newParent: The folder to move this item to.
-    /// - throws: `LocationError` if the location couldn't be moved.
-    func move(to newParent: Folder) throws {
-        try storage.move(
-            to: newParent.path + name,
-            errorReasonProvider: LocationErrorReason.moveFailed
-        )
-    }
-
-    /// Copy the contents of this location to a given folder
-    /// - parameter newParent: The folder to copy this item to.
-    /// - throws: `LocationError` if the location couldn't be copied.
-    /// - returns: The new, copied location.
-    @discardableResult
-    func copy(to folder: Folder) throws -> Self {
-        let path = folder.path + name
-        try storage.copy(to: path)
-        return try Self(path: path)
-    }
-
-    /// Delete this location. It will be permanently deleted. Use with caution.
-    /// - throws: `LocationError` if the item couldn't be deleted.
-    func delete() throws {
-        try storage.delete()
-    }
-
-    /// Assign a new `FileManager` to manage this location. Typically only used
-    /// for testing, or when building custom file systems. Returns a new instance,
-    /// doensn't modify the instance this is called on.
-    /// - parameter manager: The new file manager that should manage this location.
-    /// - throws: `LocationError` if the change couldn't be completed.
-    func managedBy(_ manager: FileManager) throws -> Self {
-        return try Self(storage: Storage(
-            path: path,
-            fileManager: manager
-        ))
-    }
+  /// Assign a new `FileManager` to manage this location. Typically only used
+  /// for testing, or when building custom file systems. Returns a new instance,
+  /// doensn't modify the instance this is called on.
+  /// - parameter manager: The new file manager that should manage this location.
+  /// - throws: `LocationError` if the change couldn't be completed.
+  public func managedBy(_ manager: FileManager) throws -> Self {
+    return try Self(storage: Storage(
+      path: path,
+      fileManager: manager))
+  }
 }
 
 // MARK: - Storage
@@ -201,861 +202,908 @@ public extension Location {
 /// interact with this type as part of the public API, instead you use the APIs
 /// exposed by `Location`, `File`, and `Folder`.
 public final class Storage<LocationType: Location> {
-    fileprivate private(set) var path: String
-    private let fileManager: FileManager
 
-    fileprivate init(path: String, fileManager: FileManager) throws {
-        self.path = path
-        self.fileManager = fileManager
-        try validatePath()
+  // MARK: Lifecycle
+
+  fileprivate init(path: String, fileManager: FileManager) throws {
+    self.path = path
+    self.fileManager = fileManager
+    try validatePath()
+  }
+
+  // MARK: Fileprivate
+
+  fileprivate private(set) var path: String
+
+  // MARK: Private
+
+  private let fileManager: FileManager
+
+  private func validatePath() throws {
+    switch LocationType.kind {
+    case .file:
+      guard !path.isEmpty else {
+        throw LocationError(path: path, reason: .emptyFilePath)
+      }
+    case .folder:
+      if path.isEmpty { path = fileManager.currentDirectoryPath }
+      if !path.hasSuffix("/") { path += "/" }
     }
 
-    private func validatePath() throws {
-        switch LocationType.kind {
-        case .file:
-            guard !path.isEmpty else {
-                throw LocationError(path: path, reason: .emptyFilePath)
-            }
-        case .folder:
-            if path.isEmpty { path = fileManager.currentDirectoryPath }
-            if !path.hasSuffix("/") { path += "/" }
-        }
-
-        if path.hasPrefix("~") {
-            let homePath = ProcessInfo.processInfo.environment["HOME"]!
-            path = homePath + path.dropFirst()
-        }
-
-        while let parentReferenceRange = path.range(of: "../") {
-            let folderPath = String(path[..<parentReferenceRange.lowerBound])
-            let parentPath = makeParentPath(for: folderPath) ?? "/"
-
-            guard fileManager.locationExists(at: parentPath, kind: .folder) else {
-                throw LocationError(path: parentPath, reason: .missing)
-            }
-
-            path.replaceSubrange(..<parentReferenceRange.upperBound, with: parentPath)
-        }
-
-        guard fileManager.locationExists(at: path, kind: LocationType.kind) else {
-            throw LocationError(path: path, reason: .missing)
-        }
+    if path.hasPrefix("~") {
+      let homePath = ProcessInfo.processInfo.environment["HOME"]!
+      path = homePath + path.dropFirst()
     }
+
+    while let parentReferenceRange = path.range(of: "../") {
+      let folderPath = String(path[..<parentReferenceRange.lowerBound])
+      let parentPath = makeParentPath(for: folderPath) ?? "/"
+
+      guard fileManager.locationExists(at: parentPath, kind: .folder) else {
+        throw LocationError(path: parentPath, reason: .missing)
+      }
+
+      path.replaceSubrange(..<parentReferenceRange.upperBound, with: parentPath)
+    }
+
+    guard fileManager.locationExists(at: path, kind: LocationType.kind) else {
+      throw LocationError(path: path, reason: .missing)
+    }
+  }
 }
 
-fileprivate extension Storage {
-    var attributes: [FileAttributeKey : Any] {
-        return (try? fileManager.attributesOfItem(atPath: path)) ?? [:]
-    }
+extension Storage {
+  fileprivate var attributes: [FileAttributeKey: Any] {
+    return (try? fileManager.attributesOfItem(atPath: path)) ?? [:]
+  }
 
-    func makeParentPath(for path: String) -> String? {
-        guard path != "/" else { return nil }
-        let url = URL(fileURLWithPath: path)
-        let components = url.pathComponents.dropFirst().dropLast()
-        guard !components.isEmpty else { return "/" }
-        return "/" + components.joined(separator: "/") + "/"
-    }
+  fileprivate func makeParentPath(for path: String) -> String? {
+    guard path != "/" else { return nil }
+    let url = URL(fileURLWithPath: path)
+    let components = url.pathComponents.dropFirst().dropLast()
+    guard !components.isEmpty else { return "/" }
+    return "/" + components.joined(separator: "/") + "/"
+  }
 
-    func move(to newPath: String,
-              errorReasonProvider: (Error) -> LocationErrorReason) throws {
-        do {
-            try fileManager.moveItem(atPath: path, toPath: newPath)
+  fileprivate func move(
+    to newPath: String,
+    errorReasonProvider: (Error) -> LocationErrorReason) throws
+  {
+    do {
+      try fileManager.moveItem(atPath: path, toPath: newPath)
 
-            switch LocationType.kind {
-            case .file:
-                path = newPath
-            case .folder:
-                path = newPath.appendingSuffixIfNeeded("/")
-            }
-        } catch {
-            throw LocationError(path: path, reason: errorReasonProvider(error))
-        }
+      switch LocationType.kind {
+      case .file:
+        path = newPath
+      case .folder:
+        path = newPath.appendingSuffixIfNeeded("/")
+      }
+    } catch {
+      throw LocationError(path: path, reason: errorReasonProvider(error))
     }
+  }
 
-    func copy(to newPath: String) throws {
-        do {
-            try fileManager.copyItem(atPath: path, toPath: newPath)
-        } catch {
-            throw LocationError(path: path, reason: .copyFailed(error))
-        }
+  fileprivate func copy(to newPath: String) throws {
+    do {
+      try fileManager.copyItem(atPath: path, toPath: newPath)
+    } catch {
+      throw LocationError(path: path, reason: .copyFailed(error))
     }
+  }
 
-    func delete() throws {
-        do {
-            try fileManager.removeItem(atPath: path)
-        } catch {
-            throw LocationError(path: path, reason: .deleteFailed(error))
-        }
+  fileprivate func delete() throws {
+    do {
+      try fileManager.removeItem(atPath: path)
+    } catch {
+      throw LocationError(path: path, reason: .deleteFailed(error))
     }
+  }
 }
 
-private extension Storage where LocationType == Folder {
-    func makeChildSequence<T: Location>() -> Folder.ChildSequence<T> {
-        return Folder.ChildSequence(
-            folder: Folder(storage: self),
-            fileManager: fileManager,
-            isRecursive: false,
-            includeHidden: false
-        )
+extension Storage where LocationType == Folder {
+  fileprivate func makeChildSequence<T: Location>() -> Folder.ChildSequence<T> {
+    return Folder.ChildSequence(
+      folder: Folder(storage: self),
+      fileManager: fileManager,
+      isRecursive: false,
+      includeHidden: false)
+  }
+
+  fileprivate func subfolder(at folderPath: String) throws -> Folder {
+    let folderPath = path + folderPath.removingPrefix("/")
+    let storage = try Storage(path: folderPath, fileManager: fileManager)
+    return Folder(storage: storage)
+  }
+
+  fileprivate func file(at filePath: String) throws -> File {
+    let filePath = path + filePath.removingPrefix("/")
+    let storage = try Storage<File>(path: filePath, fileManager: fileManager)
+    return File(storage: storage)
+  }
+
+  fileprivate func createSubfolder(at folderPath: String) throws -> Folder {
+    let folderPath = path + folderPath.removingPrefix("/")
+
+    guard folderPath != path else {
+      throw WriteError(path: folderPath, reason: .emptyPath)
     }
 
-    func subfolder(at folderPath: String) throws -> Folder {
-        let folderPath = path + folderPath.removingPrefix("/")
-        let storage = try Storage(path: folderPath, fileManager: fileManager)
-        return Folder(storage: storage)
+    do {
+      try fileManager.createDirectory(
+        atPath: folderPath,
+        withIntermediateDirectories: true)
+
+      let storage = try Storage(path: folderPath, fileManager: fileManager)
+      return Folder(storage: storage)
+    } catch {
+      throw WriteError(path: folderPath, reason: .folderCreationFailed(error))
+    }
+  }
+
+  fileprivate func createFile(at filePath: String, contents: Data?) throws -> File {
+    let filePath = path + filePath.removingPrefix("/")
+
+    guard let parentPath = makeParentPath(for: filePath) else {
+      throw WriteError(path: filePath, reason: .emptyPath)
     }
 
-    func file(at filePath: String) throws -> File {
-        let filePath = path + filePath.removingPrefix("/")
-        let storage = try Storage<File>(path: filePath, fileManager: fileManager)
-        return File(storage: storage)
+    if parentPath != path {
+      do {
+        try fileManager.createDirectory(
+          atPath: parentPath,
+          withIntermediateDirectories: true)
+      } catch {
+        throw WriteError(path: parentPath, reason: .folderCreationFailed(error))
+      }
     }
 
-    func createSubfolder(at folderPath: String) throws -> Folder {
-        let folderPath = path + folderPath.removingPrefix("/")
-
-        guard folderPath != path else {
-            throw WriteError(path: folderPath, reason: .emptyPath)
-        }
-
-        do {
-            try fileManager.createDirectory(
-                atPath: folderPath,
-                withIntermediateDirectories: true
-            )
-
-            let storage = try Storage(path: folderPath, fileManager: fileManager)
-            return Folder(storage: storage)
-        } catch {
-            throw WriteError(path: folderPath, reason: .folderCreationFailed(error))
-        }
+    guard
+      fileManager.createFile(atPath: filePath, contents: contents),
+      let storage = try? Storage<File>(path: filePath, fileManager: fileManager) else
+    {
+      throw WriteError(path: filePath, reason: .fileCreationFailed)
     }
 
-    func createFile(at filePath: String, contents: Data?) throws -> File {
-        let filePath = path + filePath.removingPrefix("/")
-
-        guard let parentPath = makeParentPath(for: filePath) else {
-            throw WriteError(path: filePath, reason: .emptyPath)
-        }
-
-        if parentPath != path {
-            do {
-                try fileManager.createDirectory(
-                    atPath: parentPath,
-                    withIntermediateDirectories: true
-                )
-            } catch {
-                throw WriteError(path: parentPath, reason: .folderCreationFailed(error))
-            }
-        }
-
-        guard fileManager.createFile(atPath: filePath, contents: contents),
-              let storage = try? Storage<File>(path: filePath, fileManager: fileManager) else {
-            throw WriteError(path: filePath, reason: .fileCreationFailed)
-        }
-
-        return File(storage: storage)
-    }
+    return File(storage: storage)
+  }
 }
 
-// MARK: - Files
+// MARK: - File
 
 /// Type that represents a file on disk. You can either reference an existing
 /// file by initializing an instance with a `path`, or you can create new files
 /// using the various `createFile...` APIs available on `Folder`.
 public struct File: Location {
-    public let storage: Storage<File>
 
-    public init(storage: Storage<File>) {
-        self.storage = storage
-    }
+  // MARK: Lifecycle
+
+  public init(storage: Storage<File>) {
+    self.storage = storage
+  }
+
   public init(from decoder: Decoder) throws {
     let container = try decoder.singleValueContainer()
     self = try File(path: container.decode(String.self))
   }
-    
+
+  /// Attempts to use `init(path:)` with argument as an absolute path. When that fails it attempts to
+  /// initialise relative to the current path. Finally if that fails the error is logged and it simply returns nil.
+  /// - Parameter argument: absolute or relative path to `FileManager.default.currentDirectoryPath`
+  public init?(argument: String) {
+    do {
+      try self.init(path: argument)
+    } catch {
+      do {
+        var currentURL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        currentURL = currentURL.appendingPathComponent(argument)
+        try self.init(path: currentURL.path)
+      } catch {
+        print("\(error)")
+        return nil
+      }
+    }
+  }
+
+  // MARK: Public
+
+  public let storage: Storage<File>
+
   public func encode(to encoder: Encoder) throws {
     var container = encoder.singleValueContainer()
     try container.encode(path)
   }
-    /// Attempts to use `init(path:)` with argument as an absolute path. When that fails it attempts to
-    /// initialise relative to the current path. Finally if that fails the error is logged and it simply returns nil.
-    /// - Parameter argument: absolute or relative path to `FileManager.default.currentDirectoryPath`
-    public init?(argument: String) {
-        do {
-            try self.init(path: argument)
-        } catch {
-            do {
-                var currentURL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
-                currentURL = currentURL.appendingPathComponent(argument)
-                try self.init(path: currentURL.path)
-            } catch {
-                print("\(error)")
-                return nil
-            }
-        }
-    }
+
 }
 
-public extension File {
-    static var kind: LocationKind {
-        return .file
+extension File {
+  public static var kind: LocationKind {
+    return .file
+  }
+
+  /// Write a new set of binary data into the file, replacing its current contents.
+  /// - parameter data: The binary data to write.
+  /// - throws: `WriteError` in case the operation couldn't be completed.
+  public func write(_ data: Data) throws {
+    do {
+      try data.write(to: url)
+    } catch {
+      throw WriteError(path: path, reason: .writeFailed(error))
+    }
+  }
+
+  /// Write a new string into the file, replacing its current contents.
+  /// - parameter string: The string to write.
+  /// - parameter encoding: The encoding of the string (default: `UTF8`).
+  /// - throws: `WriteError` in case the operation couldn't be completed.
+  public func write(_ string: String, encoding: String.Encoding = .utf8) throws {
+    guard let data = string.data(using: encoding) else {
+      throw WriteError(path: path, reason: .stringEncodingFailed(string))
     }
 
-    /// Write a new set of binary data into the file, replacing its current contents.
-    /// - parameter data: The binary data to write.
-    /// - throws: `WriteError` in case the operation couldn't be completed.
-    func write(_ data: Data) throws {
-        do {
-            try data.write(to: url)
-        } catch {
-            throw WriteError(path: path, reason: .writeFailed(error))
-        }
+    return try write(data)
+  }
+
+  /// Append a set of binary data to the file's existing contents.
+  /// - parameter data: The binary data to append.
+  /// - throws: `WriteError` in case the operation couldn't be completed.
+  public func append(_ data: Data) throws {
+    do {
+      let handle = try FileHandle(forWritingTo: url)
+      handle.seekToEndOfFile()
+      handle.write(data)
+      handle.closeFile()
+    } catch {
+      throw WriteError(path: path, reason: .writeFailed(error))
+    }
+  }
+
+  /// Append a string to the file's existing contents.
+  /// - parameter string: The string to append.
+  /// - parameter encoding: The encoding of the string (default: `UTF8`).
+  /// - throws: `WriteError` in case the operation couldn't be completed.
+  public func append(_ string: String, encoding: String.Encoding = .utf8) throws {
+    guard let data = string.data(using: encoding) else {
+      throw WriteError(path: path, reason: .stringEncodingFailed(string))
     }
 
-    /// Write a new string into the file, replacing its current contents.
-    /// - parameter string: The string to write.
-    /// - parameter encoding: The encoding of the string (default: `UTF8`).
-    /// - throws: `WriteError` in case the operation couldn't be completed.
-    func write(_ string: String, encoding: String.Encoding = .utf8) throws {
-        guard let data = string.data(using: encoding) else {
-            throw WriteError(path: path, reason: .stringEncodingFailed(string))
-        }
+    return try append(data)
+  }
 
-        return try write(data)
+  /// Read the contents of the file as binary data.
+  /// - throws: `ReadError` if the file couldn't be read.
+  public func read() throws -> Data {
+    do { return try Data(contentsOf: url) }
+    catch { throw ReadError(path: path, reason: .readFailed(error)) }
+  }
+
+  /// Read the contents of the file as a string.
+  /// - parameter encoding: The encoding to decode the file's data using (default: `UTF8`).
+  /// - throws: `ReadError` if the file couldn't be read, or if a string couldn't
+  ///   be decoded from the file's contents.
+  public func readAsString(encodedAs encoding: String.Encoding = .utf8) throws -> String {
+    guard let string = try String(data: read(), encoding: encoding) else {
+      throw ReadError(path: path, reason: .stringDecodingFailed)
     }
 
-    /// Append a set of binary data to the file's existing contents.
-    /// - parameter data: The binary data to append.
-    /// - throws: `WriteError` in case the operation couldn't be completed.
-    func append(_ data: Data) throws {
-        do {
-            let handle = try FileHandle(forWritingTo: url)
-            handle.seekToEndOfFile()
-            handle.write(data)
-            handle.closeFile()
-        } catch {
-            throw WriteError(path: path, reason: .writeFailed(error))
-        }
+    return string
+  }
+
+  /// Read the contents of the file as an integer.
+  /// - throws: `ReadError` if the file couldn't be read, or if the file's
+  ///   contents couldn't be converted into an integer.
+  public func readAsInt() throws -> Int {
+    let string = try readAsString()
+
+    guard let int = Int(string) else {
+      throw ReadError(path: path, reason: .notAnInt(string))
     }
 
-    /// Append a string to the file's existing contents.
-    /// - parameter string: The string to append.
-    /// - parameter encoding: The encoding of the string (default: `UTF8`).
-    /// - throws: `WriteError` in case the operation couldn't be completed.
-    func append(_ string: String, encoding: String.Encoding = .utf8) throws {
-        guard let data = string.data(using: encoding) else {
-            throw WriteError(path: path, reason: .stringEncodingFailed(string))
-        }
-
-        return try append(data)
-    }
-
-    /// Read the contents of the file as binary data.
-    /// - throws: `ReadError` if the file couldn't be read.
-    func read() throws -> Data {
-        do { return try Data(contentsOf: url) }
-        catch { throw ReadError(path: path, reason: .readFailed(error)) }
-    }
-
-    /// Read the contents of the file as a string.
-    /// - parameter encoding: The encoding to decode the file's data using (default: `UTF8`).
-    /// - throws: `ReadError` if the file couldn't be read, or if a string couldn't
-    ///   be decoded from the file's contents.
-    func readAsString(encodedAs encoding: String.Encoding = .utf8) throws -> String {
-        guard let string = try String(data: read(), encoding: encoding) else {
-            throw ReadError(path: path, reason: .stringDecodingFailed)
-        }
-
-        return string
-    }
-
-    /// Read the contents of the file as an integer.
-    /// - throws: `ReadError` if the file couldn't be read, or if the file's
-    ///   contents couldn't be converted into an integer.
-    func readAsInt() throws -> Int {
-        let string = try readAsString()
-
-        guard let int = Int(string) else {
-            throw ReadError(path: path, reason: .notAnInt(string))
-        }
-
-        return int
-    }
+    return int
+  }
 }
 
 #if canImport(AppKit) && !targetEnvironment(macCatalyst)
 
 import AppKit
 
-public extension File {
-    /// Open the file.
-    func open() {
-        NSWorkspace.shared.openFile(path)
-    }
+extension File {
+  /// Open the file.
+  public func open() {
+    NSWorkspace.shared.openFile(path)
+  }
 }
 
 #endif
 
-// MARK: - Folders
+// MARK: - Folder
 
 /// Type that represents a folder on disk. You can either reference an existing
 /// folder by initializing an instance with a `path`, or you can create new
 /// subfolders using this type's various `createSubfolder...` APIs.
 public struct Folder: Location {
-    public let storage: Storage<Folder>
 
-    public init(storage: Storage<Folder>) {
-        self.storage = storage
+  // MARK: Lifecycle
+
+  public init(storage: Storage<Folder>) {
+    self.storage = storage
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    self = try Folder(path: container.decode(String.self))
+  }
+
+  /// Attempts to use `init(path:)` with argument as an absolute path. When that fails it attempts to
+  /// initialise relative to the current path. Finally if that fails the error is logged and it simply returns nil.
+  /// - Parameter argument: absolute or relative path to `FileManager.default.currentDirectoryPath`
+  public init?(argument: String) {
+    try? self.init(possiblyRelativePath: argument)
+  }
+  /// Attempts to use `init(path:)` with argument as an absolute path. When that fails it attempts to
+  /// initialise relative to the current path. Finally if that fails the error is logged and it simply returns nil.
+  /// - Parameter possiblyRelativePath: absolute or relative path to `FileManager.default.currentDirectoryPath`
+  public init(possiblyRelativePath: String) throws {
+    do {
+      try self.init(path: possiblyRelativePath)
+    } catch {
+      do {
+        var currentURL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+        currentURL = currentURL.appendingPathComponent(possiblyRelativePath)
+        try self.init(path: currentURL.path)
+      } catch {
+        throw error
+      }
     }
-  
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.singleValueContainer()
-        self = try Folder(path: container.decode(String.self))
-    }
-      
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.singleValueContainer()
-        try container.encode(path)
-    }
-    
-    /// Attempts to use `init(path:)` with argument as an absolute path. When that fails it attempts to
-    /// initialise relative to the current path. Finally if that fails the error is logged and it simply returns nil.
-    /// - Parameter argument: absolute or relative path to `FileManager.default.currentDirectoryPath`
-    public init?(argument: String) {
-        do {
-            try self.init(path: argument)
-        } catch {
-            do {
-                var currentURL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
-                currentURL = currentURL.appendingPathComponent(argument)
-                try self.init(path: currentURL.path)
-            } catch {
-                print("\(error)")
-                return nil
-            }
-        }
-    }
+  }
+
+  // MARK: Public
+
+  public let storage: Storage<Folder>
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(path)
+  }
 }
 
-public extension Folder {
-    /// A sequence of child locations contained within a given folder.
-    /// You obtain an instance of this type by accessing either `files`
-    /// or `subfolders` on a `Folder` instance.
-    struct ChildSequence<Child: Location>: Sequence {
-        fileprivate let folder: Folder
-        fileprivate let fileManager: FileManager
-        fileprivate var isRecursive: Bool
-        fileprivate var includeHidden: Bool
+extension Folder {
+  /// A sequence of child locations contained within a given folder.
+  /// You obtain an instance of this type by accessing either `files`
+  /// or `subfolders` on a `Folder` instance.
+  public struct ChildSequence<Child: Location>: Sequence {
+    fileprivate let folder: Folder
+    fileprivate let fileManager: FileManager
+    fileprivate var isRecursive: Bool
+    fileprivate var includeHidden: Bool
 
-        public func makeIterator() -> ChildIterator<Child> {
-            return ChildIterator(
-                folder: folder,
-                fileManager: fileManager,
-                isRecursive: isRecursive,
-                includeHidden: includeHidden,
-                reverseTopLevelTraversal: false
-            )
-        }
+    public func makeIterator() -> ChildIterator<Child> {
+      return ChildIterator(
+        folder: folder,
+        fileManager: fileManager,
+        isRecursive: isRecursive,
+        includeHidden: includeHidden,
+        reverseTopLevelTraversal: false)
+    }
+  }
+
+  /// The type of iterator used by `ChildSequence`. You don't interact
+  /// with this type directly. See `ChildSequence` for more information.
+  public struct ChildIterator<Child: Location>: IteratorProtocol {
+
+    // MARK: Lifecycle
+
+    fileprivate init(
+      folder: Folder,
+      fileManager: FileManager,
+      isRecursive: Bool,
+      includeHidden: Bool,
+      reverseTopLevelTraversal: Bool)
+    {
+      self.folder = folder
+      self.fileManager = fileManager
+      self.isRecursive = isRecursive
+      self.includeHidden = includeHidden
+      self.reverseTopLevelTraversal = reverseTopLevelTraversal
     }
 
-    /// The type of iterator used by `ChildSequence`. You don't interact
-    /// with this type directly. See `ChildSequence` for more information.
-    struct ChildIterator<Child: Location>: IteratorProtocol {
-        private let folder: Folder
-        private let fileManager: FileManager
-        private let isRecursive: Bool
-        private let includeHidden: Bool
-        private let reverseTopLevelTraversal: Bool
-        private lazy var itemNames = loadItemNames()
-        private var index = 0
-        private var nestedIterators = [ChildIterator<Child>]()
+    // MARK: Public
 
-        fileprivate init(folder: Folder,
-                         fileManager: FileManager,
-                         isRecursive: Bool,
-                         includeHidden: Bool,
-                         reverseTopLevelTraversal: Bool) {
-            self.folder = folder
-            self.fileManager = fileManager
-            self.isRecursive = isRecursive
-            self.includeHidden = includeHidden
-            self.reverseTopLevelTraversal = reverseTopLevelTraversal
+    public mutating func next() -> Child? {
+      guard index < itemNames.count else {
+        guard var nested = nestedIterators.first else {
+          return nil
         }
 
-        public mutating func next() -> Child? {
-            guard index < itemNames.count else {
-                guard var nested = nestedIterators.first else {
-                    return nil
-                }
-
-                guard let child = nested.next() else {
-                    nestedIterators.removeFirst()
-                    return next()
-                }
-
-                nestedIterators[0] = nested
-                return child
-            }
-
-            let name = itemNames[index]
-            index += 1
-
-            if !includeHidden {
-                guard !name.hasPrefix(".") else { return next() }
-            }
-
-            let childPath = folder.path + name.removingPrefix("/")
-            let childStorage = try? Storage<Child>(path: childPath, fileManager: fileManager)
-            let child = childStorage.map(Child.init)
-
-            if isRecursive {
-                let childFolder = (child as? Folder) ?? (try? Folder(
-                    storage: Storage(path: childPath, fileManager: fileManager)
-                ))
-
-                if let childFolder = childFolder {
-                    let nested = ChildIterator(
-                        folder: childFolder,
-                        fileManager: fileManager,
-                        isRecursive: true,
-                        includeHidden: includeHidden,
-                        reverseTopLevelTraversal: false
-                    )
-
-                    nestedIterators.append(nested)
-                }
-            }
-
-            return child ?? next()
+        guard let child = nested.next() else {
+          nestedIterators.removeFirst()
+          return next()
         }
 
-        private mutating func loadItemNames() -> [String] {
-            let contents = try? fileManager.contentsOfDirectory(atPath: folder.path)
-            let names = contents?.sorted() ?? []
-            return reverseTopLevelTraversal ? names.reversed() : names
+        nestedIterators[0] = nested
+        return child
+      }
+
+      let name = itemNames[index]
+      index += 1
+
+      if !includeHidden {
+        guard !name.hasPrefix(".") else { return next() }
+      }
+
+      let childPath = folder.path + name.removingPrefix("/")
+      let childStorage = try? Storage<Child>(path: childPath, fileManager: fileManager)
+      let child = childStorage.map(Child.init)
+
+      if isRecursive {
+        let childFolder = (child as? Folder) ?? (try? Folder(
+          storage: Storage(path: childPath, fileManager: fileManager)))
+
+        if let childFolder = childFolder {
+          let nested = ChildIterator(
+            folder: childFolder,
+            fileManager: fileManager,
+            isRecursive: true,
+            includeHidden: includeHidden,
+            reverseTopLevelTraversal: false)
+
+          nestedIterators.append(nested)
         }
+      }
+
+      return child ?? next()
     }
+
+    // MARK: Private
+
+    private let folder: Folder
+    private let fileManager: FileManager
+    private let isRecursive: Bool
+    private let includeHidden: Bool
+    private let reverseTopLevelTraversal: Bool
+    private lazy var itemNames = loadItemNames()
+    private var index = 0
+    private var nestedIterators = [ChildIterator<Child>]()
+
+    private mutating func loadItemNames() -> [String] {
+      let contents = try? fileManager.contentsOfDirectory(atPath: folder.path)
+      let names = contents?.sorted() ?? []
+      return reverseTopLevelTraversal ? names.reversed() : names
+    }
+  }
 }
+
+// MARK: - Folder.ChildSequence + CustomStringConvertible
 
 extension Folder.ChildSequence: CustomStringConvertible {
-    public var description: String {
-        return lazy.map({ $0.description }).joined(separator: "\n")
-    }
+  public var description: String {
+    return lazy.map({ $0.description }).joined(separator: "\n")
+  }
 }
 
-public extension Folder.ChildSequence {
-    /// Return a new instance of this sequence that'll traverse the folder's
-    /// contents recursively, in a breadth-first manner. Complexity: `O(1)`.
-    var recursive: Folder.ChildSequence<Child> {
-        var sequence = self
-        sequence.isRecursive = true
-        return sequence
+extension Folder.ChildSequence {
+  /// Return a new instance of this sequence that'll traverse the folder's
+  /// contents recursively, in a breadth-first manner. Complexity: `O(1)`.
+  public var recursive: Folder.ChildSequence<Child> {
+    var sequence = self
+    sequence.isRecursive = true
+    return sequence
+  }
+
+  /// Return a new instance of this sequence that'll include all hidden
+  /// (dot) files when traversing the folder's contents. Complexity: `O(1)`.
+  public var includingHidden: Folder.ChildSequence<Child> {
+    var sequence = self
+    sequence.includeHidden = true
+    return sequence
+  }
+
+  /// Return the first location contained within this sequence.
+  /// Complexity: `O(1)`.
+  public var first: Child? {
+    var iterator = makeIterator()
+    return iterator.next()
+  }
+
+  /// Count the number of locations contained within this sequence.
+  /// Complexity: `O(N)`.
+  public func count() -> Int {
+    return reduce(0) { count, _ in count + 1 }
+  }
+
+  /// Gather the names of all of the locations contained within this sequence.
+  /// Complexity: `O(N)`.
+  public func names() -> [String] {
+    return map { $0.name }
+  }
+
+  /// Return the last location contained within this sequence.
+  /// Complexity: `O(N)`.
+  public func last() -> Child? {
+    var iterator = Iterator(
+      folder: folder,
+      fileManager: fileManager,
+      isRecursive: isRecursive,
+      includeHidden: includeHidden,
+      reverseTopLevelTraversal: !isRecursive)
+
+    guard isRecursive else { return iterator.next() }
+
+    var child: Child?
+
+    while let nextChild = iterator.next() {
+      child = nextChild
     }
 
-    /// Return a new instance of this sequence that'll include all hidden
-    /// (dot) files when traversing the folder's contents. Complexity: `O(1)`.
-    var includingHidden: Folder.ChildSequence<Child> {
-        var sequence = self
-        sequence.includeHidden = true
-        return sequence
-    }
+    return child
+  }
 
-    /// Count the number of locations contained within this sequence.
-    /// Complexity: `O(N)`.
-    func count() -> Int {
-        return reduce(0) { count, _ in count + 1 }
-    }
+  /// Move all locations within this sequence to a new parent folder.
+  /// - parameter folder: The folder to move all locations to.
+  /// - throws: `LocationError` if the move couldn't be completed.
+  public func move(to folder: Folder) throws {
+    try forEach { try $0.move(to: folder) }
+  }
 
-    /// Gather the names of all of the locations contained within this sequence.
-    /// Complexity: `O(N)`.
-    func names() -> [String] {
-        return map { $0.name }
-    }
-
-    /// Return the last location contained within this sequence.
-    /// Complexity: `O(N)`.
-    func last() -> Child? {
-        var iterator = Iterator(
-            folder: folder,
-            fileManager: fileManager,
-            isRecursive: isRecursive,
-            includeHidden: includeHidden,
-            reverseTopLevelTraversal: !isRecursive
-        )
-
-        guard isRecursive else { return iterator.next() }
-
-        var child: Child?
-
-        while let nextChild = iterator.next() {
-            child = nextChild
-        }
-
-        return child
-    }
-
-    /// Return the first location contained within this sequence.
-    /// Complexity: `O(1)`.
-    var first: Child? {
-        var iterator = makeIterator()
-        return iterator.next()
-    }
-
-    /// Move all locations within this sequence to a new parent folder.
-    /// - parameter folder: The folder to move all locations to.
-    /// - throws: `LocationError` if the move couldn't be completed.
-    func move(to folder: Folder) throws {
-        try forEach { try $0.move(to: folder) }
-    }
-
-    /// Delete all of the locations within this sequence. All items will
-    /// be permanently deleted. Use with caution.
-    /// - throws: `LocationError` if an item couldn't be deleted. Note that
-    ///   all items deleted up to that point won't be recovered.
-    func delete() throws {
-        try forEach { try $0.delete() }
-    }
+  /// Delete all of the locations within this sequence. All items will
+  /// be permanently deleted. Use with caution.
+  /// - throws: `LocationError` if an item couldn't be deleted. Note that
+  ///   all items deleted up to that point won't be recovered.
+  public func delete() throws {
+    try forEach { try $0.delete() }
+  }
 }
 
-public extension Folder {
-    static var kind: LocationKind {
-        return .folder
+extension Folder {
+  public static var kind: LocationKind {
+    return .folder
+  }
+
+  /// The folder that the program is currently operating in.
+  public static var current: Folder {
+    return try! Folder(path: "")
+  }
+
+  /// The root folder of the file system.
+  public static var root: Folder {
+    return try! Folder(path: "/")
+  }
+
+  /// The current user's Home folder.
+  public static var home: Folder {
+    return try! Folder(path: "~")
+  }
+
+  /// The system's temporary folder.
+  public static var temporary: Folder {
+    return try! Folder(path: NSTemporaryDirectory())
+  }
+
+  /// A sequence containing all of this folder's subfolders. Initially
+  /// non-recursive, use `recursive` on the returned sequence to change that.
+  public var subfolders: ChildSequence<Folder> {
+    return storage.makeChildSequence()
+  }
+
+  /// A sequence containing all of this folder's files. Initially
+  /// non-recursive, use `recursive` on the returned sequence to change that.
+  public var files: ChildSequence<File> {
+    return storage.makeChildSequence()
+  }
+
+  /// Return a subfolder at a given path within this folder.
+  /// - parameter path: A relative path within this folder.
+  /// - throws: `LocationError` if the subfolder couldn't be found.
+  public func subfolder(at path: String) throws -> Folder {
+    return try storage.subfolder(at: path)
+  }
+
+  /// Return a subfolder with a given name.
+  /// - parameter name: The name of the subfolder to return.
+  /// - throws: `LocationError` if the subfolder couldn't be found.
+  public func subfolder(named name: String) throws -> Folder {
+    return try storage.subfolder(at: name)
+  }
+
+  /// Return whether this folder contains a subfolder at a given path.
+  /// - parameter path: The relative path of the subfolder to look for.
+  public func containsSubfolder(at path: String) -> Bool {
+    return (try? subfolder(at: path)) != nil
+  }
+
+  /// Return whether this folder contains a subfolder with a given name.
+  /// - parameter name: The name of the subfolder to look for.
+  public func containsSubfolder(named name: String) -> Bool {
+    return (try? subfolder(named: name)) != nil
+  }
+
+  /// Create a new subfolder at a given path within this folder. In case
+  /// the intermediate folders between this folder and the new one don't
+  /// exist, those will be created as well. This method throws an error
+  /// if a folder already exists at the given path.
+  /// - parameter path: The relative path of the subfolder to create.
+  /// - throws: `WriteError` if the operation couldn't be completed.
+  @discardableResult
+  public func createSubfolder(at path: String) throws -> Folder {
+    return try storage.createSubfolder(at: path)
+  }
+
+  /// Create a new subfolder with a given name. This method throws an error
+  /// if a subfolder with the given name already exists.
+  /// - parameter name: The name of the subfolder to create.
+  /// - throws: `WriteError` if the operation couldn't be completed.
+  @discardableResult
+  public func createSubfolder(named name: String) throws -> Folder {
+    return try storage.createSubfolder(at: name)
+  }
+
+  /// Create a new subfolder at a given path within this folder. In case
+  /// the intermediate folders between this folder and the new one don't
+  /// exist, those will be created as well. If a folder already exists at
+  /// the given path, then it will be returned without modification.
+  /// - parameter path: The relative path of the subfolder.
+  /// - throws: `WriteError` if a new folder couldn't be created.
+  @discardableResult
+  public func createSubfolderIfNeeded(at path: String) throws -> Folder {
+    return try (try? subfolder(at: path)) ?? createSubfolder(at: path)
+  }
+
+  /// Create a new subfolder with a given name. If a subfolder with the given
+  /// name already exists, then it will be returned without modification.
+  /// - parameter name: The name of the subfolder.
+  /// - throws: `WriteError` if a new folder couldn't be created.
+  @discardableResult
+  public func createSubfolderIfNeeded(withName name: String) throws -> Folder {
+    return try (try? subfolder(named: name)) ?? createSubfolder(named: name)
+  }
+
+  /// Return a file at a given path within this folder.
+  /// - parameter path: A relative path within this folder.
+  /// - throws: `LocationError` if the file couldn't be found.
+  public func file(at path: String) throws -> File {
+    return try storage.file(at: path)
+  }
+
+  /// Return a file within this folder with a given name.
+  /// - parameter name: The name of the file to return.
+  /// - throws: `LocationError` if the file couldn't be found.
+  public func file(named name: String) throws -> File {
+    return try storage.file(at: name)
+  }
+
+  /// Return whether this folder contains a file at a given path.
+  /// - parameter path: The relative path of the file to look for.
+  public func containsFile(at path: String) -> Bool {
+    return (try? file(at: path)) != nil
+  }
+
+  /// Return whether this folder contains a file with a given name.
+  /// - parameter name: The name of the file to look for.
+  public func containsFile(named name: String) -> Bool {
+    return (try? file(named: name)) != nil
+  }
+
+  /// Create a new file at a given path within this folder. In case
+  /// the intermediate folders between this folder and the new file don't
+  /// exist, those will be created as well. This method throws an error
+  /// if a file already exists at the given path.
+  /// - parameter path: The relative path of the file to create.
+  /// - parameter contents: The initial `Data` that the file should contain.
+  /// - throws: `WriteError` if the operation couldn't be completed.
+  @discardableResult
+  public func createFile(at path: String, contents: Data? = nil) throws -> File {
+    return try storage.createFile(at: path, contents: contents)
+  }
+
+  /// Create a new file with a given name. This method throws an error
+  /// if a file with the given name already exists.
+  /// - parameter name: The name of the file to create.
+  /// - parameter contents: The initial `Data` that the file should contain.
+  /// - throws: `WriteError` if the operation couldn't be completed.
+  @discardableResult
+  public func createFile(named fileName: String, contents: Data? = nil) throws -> File {
+    return try storage.createFile(at: fileName, contents: contents)
+  }
+
+  /// Create a new file at a given path within this folder. In case
+  /// the intermediate folders between this folder and the new file don't
+  /// exist, those will be created as well. If a file already exists at
+  /// the given path, then it will be returned without modification.
+  /// - parameter path: The relative path of the file.
+  /// - parameter contents: The initial `Data` that any newly created file
+  ///   should contain. Will only be evaluated if needed.
+  /// - throws: `WriteError` if a new file couldn't be created.
+  @discardableResult
+  public func createFileIfNeeded(
+    at path: String,
+    contents: @autoclosure () -> Data? = nil) throws
+    -> File
+  {
+    return try (try? file(at: path)) ?? createFile(at: path, contents: contents())
+  }
+
+  /// Create a new file with a given name. If a file with the given
+  /// name already exists, then it will be returned without modification.
+  /// - parameter name: The name of the file.
+  /// - parameter contents: The initial `Data` that any newly created file
+  ///   should contain. Will only be evaluated if needed.
+  /// - throws: `WriteError` if a new file couldn't be created.
+  @discardableResult
+  public func createFileIfNeeded(
+    withName name: String,
+    contents: @autoclosure () -> Data? = nil) throws
+    -> File
+  {
+    return try (try? file(named: name)) ?? createFile(named: name, contents: contents())
+  }
+
+  /// Return whether this folder contains a given location as a direct child.
+  /// - parameter location: The location to find.
+  public func contains<T: Location>(_ location: T) -> Bool {
+    switch T.kind {
+    case .file: return containsFile(named: location.name)
+    case .folder: return containsSubfolder(named: location.name)
+    }
+  }
+
+  /// Move the contents of this folder to a new parent
+  /// - parameter folder: The new parent folder to move this folder's contents to.
+  /// - parameter includeHidden: Whether hidden files should be included (default: `false`).
+  /// - throws: `LocationError` if the operation couldn't be completed.
+  public func moveContents(to folder: Folder, includeHidden: Bool = false) throws {
+    var files = self.files
+    files.includeHidden = includeHidden
+    try files.move(to: folder)
+
+    var folders = subfolders
+    folders.includeHidden = includeHidden
+    try folders.move(to: folder)
+  }
+
+  /// Empty this folder, permanently deleting all of its contents. Use with caution.
+  /// - parameter includeHidden: Whether hidden files should also be deleted (default: `false`).
+  /// - throws: `LocationError` if the operation couldn't be completed.
+  public func empty(includingHidden includeHidden: Bool = false) throws {
+    var files = self.files
+    files.includeHidden = includeHidden
+    try files.delete()
+
+    var folders = subfolders
+    folders.includeHidden = includeHidden
+    try folders.delete()
+  }
+
+  public func isEmpty(includingHidden includeHidden: Bool = false) -> Bool {
+    var files = self.files
+    files.includeHidden = includeHidden
+
+    if files.first != nil {
+      return false
     }
 
-    /// The folder that the program is currently operating in.
-    static var current: Folder {
-        return try! Folder(path: "")
-    }
-
-    /// The root folder of the file system.
-    static var root: Folder {
-        return try! Folder(path: "/")
-    }
-
-    /// The current user's Home folder.
-    static var home: Folder {
-        return try! Folder(path: "~")
-    }
-
-    /// The system's temporary folder.
-    static var temporary: Folder {
-        return try! Folder(path: NSTemporaryDirectory())
-    }
-
-    /// A sequence containing all of this folder's subfolders. Initially
-    /// non-recursive, use `recursive` on the returned sequence to change that.
-    var subfolders: ChildSequence<Folder> {
-        return storage.makeChildSequence()
-    }
-
-    /// A sequence containing all of this folder's files. Initially
-    /// non-recursive, use `recursive` on the returned sequence to change that.
-    var files: ChildSequence<File> {
-        return storage.makeChildSequence()
-    }
-
-    /// Return a subfolder at a given path within this folder.
-    /// - parameter path: A relative path within this folder.
-    /// - throws: `LocationError` if the subfolder couldn't be found.
-    func subfolder(at path: String) throws -> Folder {
-        return try storage.subfolder(at: path)
-    }
-
-    /// Return a subfolder with a given name.
-    /// - parameter name: The name of the subfolder to return.
-    /// - throws: `LocationError` if the subfolder couldn't be found.
-    func subfolder(named name: String) throws -> Folder {
-        return try storage.subfolder(at: name)
-    }
-
-    /// Return whether this folder contains a subfolder at a given path.
-    /// - parameter path: The relative path of the subfolder to look for.
-    func containsSubfolder(at path: String) -> Bool {
-        return (try? subfolder(at: path)) != nil
-    }
-
-    /// Return whether this folder contains a subfolder with a given name.
-    /// - parameter name: The name of the subfolder to look for.
-    func containsSubfolder(named name: String) -> Bool {
-        return (try? subfolder(named: name)) != nil
-    }
-
-    /// Create a new subfolder at a given path within this folder. In case
-    /// the intermediate folders between this folder and the new one don't
-    /// exist, those will be created as well. This method throws an error
-    /// if a folder already exists at the given path.
-    /// - parameter path: The relative path of the subfolder to create.
-    /// - throws: `WriteError` if the operation couldn't be completed.
-    @discardableResult
-    func createSubfolder(at path: String) throws -> Folder {
-        return try storage.createSubfolder(at: path)
-    }
-
-    /// Create a new subfolder with a given name. This method throws an error
-    /// if a subfolder with the given name already exists.
-    /// - parameter name: The name of the subfolder to create.
-    /// - throws: `WriteError` if the operation couldn't be completed.
-    @discardableResult
-    func createSubfolder(named name: String) throws -> Folder {
-        return try storage.createSubfolder(at: name)
-    }
-
-    /// Create a new subfolder at a given path within this folder. In case
-    /// the intermediate folders between this folder and the new one don't
-    /// exist, those will be created as well. If a folder already exists at
-    /// the given path, then it will be returned without modification.
-    /// - parameter path: The relative path of the subfolder.
-    /// - throws: `WriteError` if a new folder couldn't be created.
-    @discardableResult
-    func createSubfolderIfNeeded(at path: String) throws -> Folder {
-        return try (try? subfolder(at: path)) ?? createSubfolder(at: path)
-    }
-
-    /// Create a new subfolder with a given name. If a subfolder with the given
-    /// name already exists, then it will be returned without modification.
-    /// - parameter name: The name of the subfolder.
-    /// - throws: `WriteError` if a new folder couldn't be created.
-    @discardableResult
-    func createSubfolderIfNeeded(withName name: String) throws -> Folder {
-        return try (try? subfolder(named: name)) ?? createSubfolder(named: name)
-    }
-
-    /// Return a file at a given path within this folder.
-    /// - parameter path: A relative path within this folder.
-    /// - throws: `LocationError` if the file couldn't be found.
-    func file(at path: String) throws -> File {
-        return try storage.file(at: path)
-    }
-
-    /// Return a file within this folder with a given name.
-    /// - parameter name: The name of the file to return.
-    /// - throws: `LocationError` if the file couldn't be found.
-    func file(named name: String) throws -> File {
-        return try storage.file(at: name)
-    }
-
-    /// Return whether this folder contains a file at a given path.
-    /// - parameter path: The relative path of the file to look for.
-    func containsFile(at path: String) -> Bool {
-        return (try? file(at: path)) != nil
-    }
-
-    /// Return whether this folder contains a file with a given name.
-    /// - parameter name: The name of the file to look for.
-    func containsFile(named name: String) -> Bool {
-        return (try? file(named: name)) != nil
-    }
-
-    /// Create a new file at a given path within this folder. In case
-    /// the intermediate folders between this folder and the new file don't
-    /// exist, those will be created as well. This method throws an error
-    /// if a file already exists at the given path.
-    /// - parameter path: The relative path of the file to create.
-    /// - parameter contents: The initial `Data` that the file should contain.
-    /// - throws: `WriteError` if the operation couldn't be completed.
-    @discardableResult
-    func createFile(at path: String, contents: Data? = nil) throws -> File {
-        return try storage.createFile(at: path, contents: contents)
-    }
-
-    /// Create a new file with a given name. This method throws an error
-    /// if a file with the given name already exists.
-    /// - parameter name: The name of the file to create.
-    /// - parameter contents: The initial `Data` that the file should contain.
-    /// - throws: `WriteError` if the operation couldn't be completed.
-    @discardableResult
-    func createFile(named fileName: String, contents: Data? = nil) throws -> File {
-        return try storage.createFile(at: fileName, contents: contents)
-    }
-
-    /// Create a new file at a given path within this folder. In case
-    /// the intermediate folders between this folder and the new file don't
-    /// exist, those will be created as well. If a file already exists at
-    /// the given path, then it will be returned without modification.
-    /// - parameter path: The relative path of the file.
-    /// - parameter contents: The initial `Data` that any newly created file
-    ///   should contain. Will only be evaluated if needed.
-    /// - throws: `WriteError` if a new file couldn't be created.
-    @discardableResult
-    func createFileIfNeeded(at path: String,
-                            contents: @autoclosure () -> Data? = nil) throws -> File {
-        return try (try? file(at: path)) ?? createFile(at: path, contents: contents())
-    }
-
-    /// Create a new file with a given name. If a file with the given
-    /// name already exists, then it will be returned without modification.
-    /// - parameter name: The name of the file.
-    /// - parameter contents: The initial `Data` that any newly created file
-    ///   should contain. Will only be evaluated if needed.
-    /// - throws: `WriteError` if a new file couldn't be created.
-    @discardableResult
-    func createFileIfNeeded(withName name: String,
-                            contents: @autoclosure () -> Data? = nil) throws -> File {
-        return try (try? file(named: name)) ?? createFile(named: name, contents: contents())
-    }
-
-    /// Return whether this folder contains a given location as a direct child.
-    /// - parameter location: The location to find.
-    func contains<T: Location>(_ location: T) -> Bool {
-        switch T.kind {
-        case .file: return containsFile(named: location.name)
-        case .folder: return containsSubfolder(named: location.name)
-        }
-    }
-
-    /// Move the contents of this folder to a new parent
-    /// - parameter folder: The new parent folder to move this folder's contents to.
-    /// - parameter includeHidden: Whether hidden files should be included (default: `false`).
-    /// - throws: `LocationError` if the operation couldn't be completed.
-    func moveContents(to folder: Folder, includeHidden: Bool = false) throws {
-        var files = self.files
-        files.includeHidden = includeHidden
-        try files.move(to: folder)
-
-        var folders = subfolders
-        folders.includeHidden = includeHidden
-        try folders.move(to: folder)
-    }
-
-    /// Empty this folder, permanently deleting all of its contents. Use with caution.
-    /// - parameter includeHidden: Whether hidden files should also be deleted (default: `false`).
-    /// - throws: `LocationError` if the operation couldn't be completed.
-    func empty(includingHidden includeHidden: Bool = false) throws {
-        var files = self.files
-        files.includeHidden = includeHidden
-        try files.delete()
-
-        var folders = subfolders
-        folders.includeHidden = includeHidden
-        try folders.delete()
-    }
-    
-    func isEmpty(includingHidden includeHidden: Bool = false) -> Bool {
-        var files = self.files
-        files.includeHidden = includeHidden
-        
-        if files.first != nil {
-            return false
-        }
-
-        var folders = subfolders
-        folders.includeHidden = includeHidden
-        return folders.first == nil
-    }
+    var folders = subfolders
+    folders.includeHidden = includeHidden
+    return folders.first == nil
+  }
 }
 
 #if os(iOS) || os(tvOS) || os(macOS)
-public extension Folder {
-    /// Resolve a folder that matches a search path within a given domain.
-    /// - parameter searchPath: The directory path to search for.
-    /// - parameter domain: The domain to search in.
-    /// - parameter fileManager: Which file manager to search using.
-    /// - throws: `LocationError` if no folder could be resolved.
-    static func matching(
-        _ searchPath: FileManager.SearchPathDirectory,
-        in domain: FileManager.SearchPathDomainMask = .userDomainMask,
-        resolvedBy fileManager: FileManager = .default
-    ) throws -> Folder {
-        let urls = fileManager.urls(for: searchPath, in: domain)
+extension Folder {
+  /// The current user's Documents folder
+  public static var documents: Folder? {
+    return try? .matching(.documentDirectory)
+  }
 
-        guard let match = urls.first else {
-            throw LocationError(
-                path: "",
-                reason: .unresolvedSearchPath(searchPath, domain: domain)
-            )
-        }
+  /// The current user's Library folder
+  public static var library: Folder? {
+    return try? .matching(.libraryDirectory)
+  }
 
-        return try Folder(storage: Storage(
-            path: match.relativePath,
-            fileManager: fileManager
-        ))
+  /// Resolve a folder that matches a search path within a given domain.
+  /// - parameter searchPath: The directory path to search for.
+  /// - parameter domain: The domain to search in.
+  /// - parameter fileManager: Which file manager to search using.
+  /// - throws: `LocationError` if no folder could be resolved.
+  public static func matching(
+    _ searchPath: FileManager.SearchPathDirectory,
+    in domain: FileManager.SearchPathDomainMask = .userDomainMask,
+    resolvedBy fileManager: FileManager = .default) throws
+    -> Folder
+  {
+    let urls = fileManager.urls(for: searchPath, in: domain)
+
+    guard let match = urls.first else {
+      throw LocationError(
+        path: "",
+        reason: .unresolvedSearchPath(searchPath, domain: domain))
     }
 
-    /// The current user's Documents folder
-    static var documents: Folder? {
-        return try? .matching(.documentDirectory)
-    }
+    return try Folder(storage: Storage(
+      path: match.relativePath,
+      fileManager: fileManager))
+  }
 
-    /// The current user's Library folder
-    static var library: Folder? {
-        return try? .matching(.libraryDirectory)
-    }
 }
 #endif
 
-// MARK: - Errors
+// MARK: - FilesError
 
 /// Error type thrown by all of Files' throwing APIs.
 public struct FilesError<Reason>: Error {
-    /// The absolute path that the error occured at.
-    public var path: String
-    /// The reason that the error occured.
-    public var reason: Reason
+  /// The absolute path that the error occured at.
+  public var path: String
+  /// The reason that the error occured.
+  public var reason: Reason
 
-    /// Initialize an instance with a path and a reason.
-    /// - parameter path: The absolute path that the error occured at.
-    /// - parameter reason: The reason that the error occured.
-    public init(path: String, reason: Reason) {
-        self.path = path
-        self.reason = reason
-    }
+  /// Initialize an instance with a path and a reason.
+  /// - parameter path: The absolute path that the error occured at.
+  /// - parameter reason: The reason that the error occured.
+  public init(path: String, reason: Reason) {
+    self.path = path
+    self.reason = reason
+  }
 }
+
+// MARK: CustomStringConvertible
 
 extension FilesError: CustomStringConvertible {
-    public var description: String {
-        return """
-        Files encountered an error at '\(path)'.
-        Reason: \(reason)
-        """
-    }
+  public var description: String {
+    return """
+      Files encountered an error at '\(path)'.
+      Reason: \(reason)
+      """
+  }
 }
+
+// MARK: - LocationErrorReason
 
 /// Enum listing reasons that a location manipulation could fail.
 public enum LocationErrorReason {
-    /// The location couldn't be found.
-    case missing
-    /// An empty path was given when refering to a file.
-    case emptyFilePath
-    /// The user attempted to rename the file system's root folder.
-    case cannotRenameRoot
-    /// A rename operation failed with an underlying system error.
-    case renameFailed(Error)
-    /// A move operation failed with an underlying system error.
-    case moveFailed(Error)
-    /// A copy operation failed with an underlying system error.
-    case copyFailed(Error)
-    /// A delete operation failed with an underlying system error.
-    case deleteFailed(Error)
-    /// A search path couldn't be resolved within a given domain.
-    case unresolvedSearchPath(
-        FileManager.SearchPathDirectory,
-        domain: FileManager.SearchPathDomainMask
-    )
+  /// The location couldn't be found.
+  case missing
+  /// An empty path was given when refering to a file.
+  case emptyFilePath
+  /// The user attempted to rename the file system's root folder.
+  case cannotRenameRoot
+  /// A rename operation failed with an underlying system error.
+  case renameFailed(Error)
+  /// A move operation failed with an underlying system error.
+  case moveFailed(Error)
+  /// A copy operation failed with an underlying system error.
+  case copyFailed(Error)
+  /// A delete operation failed with an underlying system error.
+  case deleteFailed(Error)
+  /// A search path couldn't be resolved within a given domain.
+  case unresolvedSearchPath(
+    FileManager.SearchPathDirectory,
+    domain: FileManager.SearchPathDomainMask)
 }
+
+// MARK: - WriteErrorReason
 
 /// Enum listing reasons that a write operation could fail.
 public enum WriteErrorReason {
-    /// An empty path was given when writing or creating a location.
-    case emptyPath
-    /// A folder couldn't be created because of an underlying system error.
-    case folderCreationFailed(Error)
-    /// A file couldn't be created.
-    case fileCreationFailed
-    /// A file couldn't be written to because of an underlying system error.
-    case writeFailed(Error)
-    /// Failed to encode a string into binary data.
-    case stringEncodingFailed(String)
+  /// An empty path was given when writing or creating a location.
+  case emptyPath
+  /// A folder couldn't be created because of an underlying system error.
+  case folderCreationFailed(Error)
+  /// A file couldn't be created.
+  case fileCreationFailed
+  /// A file couldn't be written to because of an underlying system error.
+  case writeFailed(Error)
+  /// Failed to encode a string into binary data.
+  case stringEncodingFailed(String)
 }
+
+// MARK: - ReadErrorReason
 
 /// Enum listing reasons that a read operation could fail.
 public enum ReadErrorReason {
-    /// A file couldn't be read because of an underlying system error.
-    case readFailed(Error)
-    /// Failed to decode a given set of data into a string.
-    case stringDecodingFailed
-    /// Encountered a string that doesn't contain an integer.
-    case notAnInt(String)
+  /// A file couldn't be read because of an underlying system error.
+  case readFailed(Error)
+  /// Failed to decode a given set of data into a string.
+  case stringDecodingFailed
+  /// Encountered a string that doesn't contain an integer.
+  case notAnInt(String)
 }
 
 /// Error thrown by location operations - such as find, move, copy and delete.
@@ -1067,34 +1115,34 @@ public typealias ReadError = FilesError<ReadErrorReason>
 
 // MARK: - Private system extensions
 
-private extension FileManager {
-    func locationExists(at path: String, kind: LocationKind) -> Bool {
-        var isFolder: ObjCBool = false
+extension FileManager {
+  fileprivate func locationExists(at path: String, kind: LocationKind) -> Bool {
+    var isFolder: ObjCBool = false
 
-        guard fileExists(atPath: path, isDirectory: &isFolder) else {
-            return false
-        }
-
-        switch kind {
-        case .file: return !isFolder.boolValue
-        case .folder: return isFolder.boolValue
-        }
+    guard fileExists(atPath: path, isDirectory: &isFolder) else {
+      return false
     }
+
+    switch kind {
+    case .file: return !isFolder.boolValue
+    case .folder: return isFolder.boolValue
+    }
+  }
 }
 
-private extension String {
-    func removingPrefix(_ prefix: String) -> String {
-        guard hasPrefix(prefix) else { return self }
-        return String(dropFirst(prefix.count))
-    }
+extension String {
+  fileprivate func removingPrefix(_ prefix: String) -> String {
+    guard hasPrefix(prefix) else { return self }
+    return String(dropFirst(prefix.count))
+  }
 
-    func removingSuffix(_ suffix: String) -> String {
-        guard hasSuffix(suffix) else { return self }
-        return String(dropLast(suffix.count))
-    }
+  fileprivate func removingSuffix(_ suffix: String) -> String {
+    guard hasSuffix(suffix) else { return self }
+    return String(dropLast(suffix.count))
+  }
 
-    func appendingSuffixIfNeeded(_ suffix: String) -> String {
-        guard !hasSuffix(suffix) else { return self }
-        return appending(suffix)
-    }
+  fileprivate func appendingSuffixIfNeeded(_ suffix: String) -> String {
+    guard !hasSuffix(suffix) else { return self }
+    return appending(suffix)
+  }
 }

--- a/Sources/Files.swift
+++ b/Sources/Files.swift
@@ -390,16 +390,22 @@ public struct File: Location {
   /// initialise relative to the current path. Finally if that fails the error is logged and it simply returns nil.
   /// - Parameter argument: absolute or relative path to `FileManager.default.currentDirectoryPath`
   public init?(argument: String) {
+    try? self.init(possiblyRelativePath: argument)
+  }
+  
+  /// Attempts to use `init(path:)` with argument as an absolute path. When that fails it attempts to
+  /// initialise relative to the current path. Finally if that fails the error is logged and it simply returns nil.
+  /// - Parameter possiblyRelativePath: absolute or relative path to `FileManager.default.currentDirectoryPath`
+  public init(possiblyRelativePath: String) throws {
     do {
-      try self.init(path: argument)
+      try self.init(path: possiblyRelativePath)
     } catch {
       do {
         var currentURL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
-        currentURL = currentURL.appendingPathComponent(argument)
+        currentURL = currentURL.appendingPathComponent(possiblyRelativePath)
         try self.init(path: currentURL.path)
       } catch {
-        print("\(error)")
-        return nil
+        throw error
       }
     }
   }

--- a/Sources/Files.swift
+++ b/Sources/Files.swift
@@ -23,6 +23,7 @@
  */
 
 import Foundation
+import ArgumentParser
 
 // MARK: - Locations
 
@@ -35,7 +36,7 @@ public enum LocationKind {
 }
 
 /// Protocol adopted by types that represent locations on a file system.
-public protocol Location: Equatable, CustomStringConvertible {
+public protocol Location: Equatable, CustomStringConvertible, ExpressibleByArgument {
     /// The kind of location that is being represented (see `LocationKind`).
     static var kind: LocationKind { get }
     /// The underlying storage for the item at the represented location.
@@ -368,6 +369,24 @@ public struct File: Location {
     public init(storage: Storage<File>) {
         self.storage = storage
     }
+    
+    /// Attempts to use `init(path:)` with argument as an absolute path. When that fails it attempts to
+    /// initialise relative to the current path. Finally if that fails the error is logged and it simply returns nil.
+    /// - Parameter argument: absolute or relative path to `FileManager.default.currentDirectoryPath`
+    public init?(argument: String) {
+        do {
+            try self.init(path: argument)
+        } catch {
+            do {
+                var currentURL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+                currentURL = currentURL.appendingPathComponent(argument)
+                try self.init(path: currentURL.path)
+            } catch {
+                print("\(error)")
+                return nil
+            }
+        }
+    }
 }
 
 public extension File {
@@ -480,6 +499,24 @@ public struct Folder: Location {
 
     public init(storage: Storage<Folder>) {
         self.storage = storage
+    }
+    
+    /// Attempts to use `init(path:)` with argument as an absolute path. When that fails it attempts to
+    /// initialise relative to the current path. Finally if that fails the error is logged and it simply returns nil.
+    /// - Parameter argument: absolute or relative path to `FileManager.default.currentDirectoryPath`
+    public init?(argument: String) {
+        do {
+            try self.init(path: argument)
+        } catch {
+            do {
+                var currentURL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
+                currentURL = currentURL.appendingPathComponent(argument)
+                try self.init(path: currentURL.path)
+            } catch {
+                print("\(error)")
+                return nil
+            }
+        }
     }
 }
 

--- a/Sources/Files.swift
+++ b/Sources/Files.swift
@@ -36,7 +36,7 @@ public enum LocationKind {
 }
 
 /// Protocol adopted by types that represent locations on a file system.
-public protocol Location: Equatable, CustomStringConvertible, ExpressibleByArgument {
+public protocol Location: Equatable, CustomStringConvertible, ExpressibleByArgument, Codable {
     /// The kind of location that is being represented (see `LocationKind`).
     static var kind: LocationKind { get }
     /// The underlying storage for the item at the represented location.
@@ -369,7 +369,15 @@ public struct File: Location {
     public init(storage: Storage<File>) {
         self.storage = storage
     }
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    self = try File(path: container.decode(String.self))
+  }
     
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.singleValueContainer()
+    try container.encode(path)
+  }
     /// Attempts to use `init(path:)` with argument as an absolute path. When that fails it attempts to
     /// initialise relative to the current path. Finally if that fails the error is logged and it simply returns nil.
     /// - Parameter argument: absolute or relative path to `FileManager.default.currentDirectoryPath`
@@ -499,6 +507,16 @@ public struct Folder: Location {
 
     public init(storage: Storage<Folder>) {
         self.storage = storage
+    }
+  
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        self = try Folder(path: container.decode(String.self))
+    }
+      
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(path)
     }
     
     /// Attempts to use `init(path:)` with argument as an absolute path. When that fails it attempts to

--- a/Tests/FilesTests/FilesTests.swift
+++ b/Tests/FilesTests/FilesTests.swift
@@ -25,6 +25,13 @@
 import Foundation
 import XCTest
 import Files
+import ArgumentParser
+
+struct DoMagic: ParsableCommand {
+    @Option private var folder: Folder?
+    @Option private var file: File?
+}
+
 
 class FilesTests: XCTestCase {
     private var folder: Folder!

--- a/Tests/FilesTests/FilesTests.swift
+++ b/Tests/FilesTests/FilesTests.swift
@@ -1,992 +1,998 @@
-/**
- *  Files
- *
- *  Copyright (c) 2017-2019 John Sundell. Licensed under the MIT license, as follows:
- *
- *  Permission is hereby granted, free of charge, to any person obtaining a copy
- *  of this software and associated documentation files (the "Software"), to deal
- *  in the Software without restriction, including without limitation the rights
- *  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
- *  copies of the Software, and to permit persons to whom the Software is
- *  furnished to do so, subject to the following conditions:
- *
- *  The above copyright notice and this permission notice shall be included in all
- *  copies or substantial portions of the Software.
- *
- *  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
- *  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
- *  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
- *  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
- *  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
- *  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
- *  SOFTWARE.
- */
+///  Files
+/// 
+///  Copyright (c) 2017-2019 John Sundell. Licensed under the MIT license, as follows:
+/// 
+///  Permission is hereby granted, free of charge, to any person obtaining a copy
+///  of this software and associated documentation files (the "Software"), to deal
+///  in the Software without restriction, including without limitation the rights
+///  to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+///  copies of the Software, and to permit persons to whom the Software is
+///  furnished to do so, subject to the following conditions:
+/// 
+///  The above copyright notice and this permission notice shall be included in all
+///  copies or substantial portions of the Software.
+/// 
+///  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+///  IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+///  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+///  AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+///  LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+///  OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+///  SOFTWARE.
 
+import ArgumentParser
+import Files
 import Foundation
 import XCTest
-import Files
-import ArgumentParser
+
+// MARK: - DoMagic
 
 struct DoMagic: ParsableCommand {
-    @Option private var folder: Folder?
-    @Option private var file: File?
+  @Option private var folder: Folder?
+  @Option private var file: File?
 }
 
+// MARK: - FilesTests
 
 class FilesTests: XCTestCase {
-    private var folder: Folder!
-
-    // MARK: - XCTestCase
-
-    override func setUp() {
-        super.setUp()
-        folder = try! Folder.home.createSubfolderIfNeeded(withName: ".filesTest")
-        try! folder.empty()
-    }
-
-    override func tearDown() {
-        try? folder.delete()
-        super.tearDown()
-    }
-    
-    // MARK: - Tests
-    
-    func testCreatingAndDeletingFile() {
-        performTest {
-            // Verify that the file doesn't exist
-            XCTAssertFalse(folder.containsFile(named: "test.txt"))
-
-            // Create a file and verify its properties
-            let file = try folder.createFile(named: "test.txt")
-            XCTAssertEqual(file.name, "test.txt")
-            XCTAssertEqual(file.path, folder.path + "test.txt")
-            XCTAssertEqual(file.extension, "txt")
-            XCTAssertEqual(file.nameExcludingExtension, "test")
-            try XCTAssertEqual(file.read(), Data())
-            
-            // You should now be able to access the file using its path and through the parent
-            _ = try File(path: file.path)
-            XCTAssertTrue(folder.containsFile(named: "test.txt"))
-
-            try file.delete()
-            
-            // Attempting to read the file should now throw an error
-            try assert(file.read(), throwsErrorOfType: ReadError.self)
-            
-            // Attempting to create a File instance with the path should now also fail
-            try assert(File(path: file.path), throwsErrorOfType: LocationError.self)
-        }
+
+  // MARK: Internal
+
+  // MARK: - Linux
+
+  static var allTests = [
+    ("testCreatingAndDeletingFile", testCreatingAndDeletingFile),
+    ("testCreatingFileAtPath", testCreatingFileAtPath),
+    ("testDroppingLeadingSlashWhenCreatingFileAtPath", testDroppingLeadingSlashWhenCreatingFileAtPath),
+    ("testCreatingAndDeletingFolder", testCreatingAndDeletingFolder),
+    ("testCreatingSubfolderAtPath", testCreatingSubfolderAtPath),
+    ("testDroppingLeadingSlashWhenCreatingSubfolderAtPath", testDroppingLeadingSlashWhenCreatingSubfolderAtPath),
+    ("testReadingFileAsString", testReadingFileAsString),
+    ("testReadingFileAsInt", testReadingFileAsInt),
+    ("testRenamingFile", testRenamingFile),
+    ("testRenamingFileWithNameIncludingExtension", testRenamingFileWithNameIncludingExtension),
+    ("testReadingFileWithRelativePath", testReadingFileWithRelativePath),
+    ("testReadingFileWithTildePath", testReadingFileWithTildePath),
+    ("testReadingFileFromCurrentFoldersParent", testReadingFileFromCurrentFoldersParent),
+    ("testReadingFileWithMultipleParentReferencesWithinPath", testReadingFileWithMultipleParentReferencesWithinPath),
+    ("testRenamingFolder", testRenamingFolder),
+    ("testAccesingFileByPath", testAccesingFileByPath),
+    ("testAccessingSubfolderByPath", testAccessingSubfolderByPath),
+    ("testEmptyingFolder", testEmptyingFolder),
+    ("testEmptyingFolderWithHiddenFiles", testEmptyingFolderWithHiddenFiles),
+    ("testCheckingEmptyFolders", testCheckingEmptyFolders),
+    ("testMovingFiles", testMovingFiles),
+    ("testCopyingFiles", testCopyingFiles),
+    ("testCopyingFolders", testCopyingFolders),
+    ("testEnumeratingFiles", testEnumeratingFiles),
+    ("testEnumeratingFilesIncludingHidden", testEnumeratingFilesIncludingHidden),
+    ("testEnumeratingFilesRecursively", testEnumeratingFilesRecursively),
+    ("testEnumeratingSubfolders", testEnumeratingSubfolders),
+    ("testEnumeratingSubfoldersRecursively", testEnumeratingSubfoldersRecursively),
+    ("testRenamingFoldersWhileEnumeratingSubfoldersRecursively", testRenamingFoldersWhileEnumeratingSubfoldersRecursively),
+    ("testFirstAndLastInFileSequence", testFirstAndLastInFileSequence),
+    ("testConvertingFileSequenceToRecursive", testConvertingFileSequenceToRecursive),
+    ("testModificationDate", testModificationDate),
+    ("testParent", testParent),
+    ("testRootFolderParentIsNil", testRootFolderParentIsNil),
+    ("testRootSubfolderParentIsRoot", testRootSubfolderParentIsRoot),
+    ("testOpeningFileWithEmptyPathThrows", testOpeningFileWithEmptyPathThrows),
+    ("testDeletingNonExistingFileThrows", testDeletingNonExistingFileThrows),
+    ("testWritingDataToFile", testWritingDataToFile),
+    ("testWritingStringToFile", testWritingStringToFile),
+    ("testAppendingDataToFile", testAppendingDataToFile),
+    ("testAppendingStringToFile", testAppendingStringToFile),
+    ("testFileDescription", testFileDescription),
+    ("testFolderDescription", testFolderDescription),
+    ("testFilesDescription", testFilesDescription),
+    ("testSubfoldersDescription", testSubfoldersDescription),
+    ("testMovingFolderContents", testMovingFolderContents),
+    ("testMovingFolderHiddenContents", testMovingFolderHiddenContents),
+    ("testAccessingHomeFolder", testAccessingHomeFolder),
+    ("testAccessingCurrentWorkingDirectory", testAccessingCurrentWorkingDirectory),
+    ("testNameExcludingExtensionWithLongFileName", testNameExcludingExtensionWithLongFileName),
+    ("testRelativePaths", testRelativePaths),
+    ("testRelativePathIsAbsolutePathForNonParent", testRelativePathIsAbsolutePathForNonParent),
+    ("testCreateFileIfNeeded", testCreateFileIfNeeded),
+    ("testCreateFolderIfNeeded", testCreateFolderIfNeeded),
+    ("testCreateSubfolderIfNeeded", testCreateSubfolderIfNeeded),
+    ("testCreatingFileWithString", testCreatingFileWithString),
+    ("testUsingCustomFileManager", testUsingCustomFileManager),
+    ("testFolderContainsFile", testFolderContainsFile),
+    ("testFolderContainsSubfolder", testFolderContainsSubfolder),
+    ("testErrorDescriptions", testErrorDescriptions),
+  ]
+
+  // MARK: - XCTestCase
+
+  override func setUp() {
+    super.setUp()
+    folder = try! Folder.home.createSubfolderIfNeeded(withName: ".filesTest")
+    try! folder.empty()
+  }
+
+  override func tearDown() {
+    try? folder.delete()
+    super.tearDown()
+  }
+
+  // MARK: - Tests
+
+  func testCreatingAndDeletingFile() {
+    performTest {
+      // Verify that the file doesn't exist
+      XCTAssertFalse(folder.containsFile(named: "test.txt"))
+
+      // Create a file and verify its properties
+      let file = try folder.createFile(named: "test.txt")
+      XCTAssertEqual(file.name, "test.txt")
+      XCTAssertEqual(file.path, folder.path + "test.txt")
+      XCTAssertEqual(file.extension, "txt")
+      XCTAssertEqual(file.nameExcludingExtension, "test")
+      try XCTAssertEqual(file.read(), Data())
+
+      // You should now be able to access the file using its path and through the parent
+      _ = try File(path: file.path)
+      XCTAssertTrue(folder.containsFile(named: "test.txt"))
+
+      try file.delete()
+
+      // Attempting to read the file should now throw an error
+      try assert(file.read(), throwsErrorOfType: ReadError.self)
+
+      // Attempting to create a File instance with the path should now also fail
+      try assert(File(path: file.path), throwsErrorOfType: LocationError.self)
     }
+  }
 
-    func testCreatingFileAtPath() {
-        performTest {
-            let path = "a/b/c.txt"
+  func testCreatingFileAtPath() {
+    performTest {
+      let path = "a/b/c.txt"
 
-            XCTAssertFalse(folder.containsFile(at: path))
-            try folder.createFile(at: path, contents: Data("Hello".utf8))
+      XCTAssertFalse(folder.containsFile(at: path))
+      try folder.createFile(at: path, contents: Data("Hello".utf8))
 
-            XCTAssertTrue(folder.containsFile(at: path))
-            XCTAssertTrue(folder.containsSubfolder(named: "a"))
-            XCTAssertTrue(folder.containsSubfolder(at: "a/b"))
+      XCTAssertTrue(folder.containsFile(at: path))
+      XCTAssertTrue(folder.containsSubfolder(named: "a"))
+      XCTAssertTrue(folder.containsSubfolder(at: "a/b"))
 
-            let file = try folder.createFileIfNeeded(at: path)
-            XCTAssertEqual(try file.readAsString(), "Hello")
-        }
+      let file = try folder.createFileIfNeeded(at: path)
+      XCTAssertEqual(try file.readAsString(), "Hello")
     }
+  }
 
-    func testCreatingFileIfNeededAtPath() {
-        performTest {
-            let path = "a/b/c.txt"
+  func testCreatingFileIfNeededAtPath() {
+    performTest {
+      let path = "a/b/c.txt"
 
-            XCTAssertFalse(folder.containsFile(at: path))
-            var file = try folder.createFileIfNeeded(at: path, contents: Data("Hello".utf8))
+      XCTAssertFalse(folder.containsFile(at: path))
+      var file = try folder.createFileIfNeeded(at: path, contents: Data("Hello".utf8))
 
-            XCTAssertTrue(folder.containsFile(at: path))
-            XCTAssertTrue(folder.containsSubfolder(named: "a"))
-            XCTAssertTrue(folder.containsSubfolder(at: "a/b"))
+      XCTAssertTrue(folder.containsFile(at: path))
+      XCTAssertTrue(folder.containsSubfolder(named: "a"))
+      XCTAssertTrue(folder.containsSubfolder(at: "a/b"))
 
-            file = try folder.createFileIfNeeded(at: path, contents: Data())
-            XCTAssertEqual(try file.readAsString(), "Hello")
-        }
+      file = try folder.createFileIfNeeded(at: path, contents: Data())
+      XCTAssertEqual(try file.readAsString(), "Hello")
     }
+  }
 
-    func testDroppingLeadingSlashWhenCreatingFileAtPath() {
-        performTest {
-            let path = "/a/b/c.txt"
+  func testDroppingLeadingSlashWhenCreatingFileAtPath() {
+    performTest {
+      let path = "/a/b/c.txt"
 
-            XCTAssertFalse(folder.containsFile(at: path))
-            try folder.createFile(at: path, contents: Data("Hello".utf8))
+      XCTAssertFalse(folder.containsFile(at: path))
+      try folder.createFile(at: path, contents: Data("Hello".utf8))
 
-            XCTAssertTrue(folder.containsFile(at: path))
-            XCTAssertTrue(folder.containsSubfolder(named: "a"))
-            XCTAssertTrue(folder.containsSubfolder(at: "/a/b"))
+      XCTAssertTrue(folder.containsFile(at: path))
+      XCTAssertTrue(folder.containsSubfolder(named: "a"))
+      XCTAssertTrue(folder.containsSubfolder(at: "/a/b"))
 
-            let file = try folder.createFileIfNeeded(at: path)
-            XCTAssertEqual(try file.readAsString(), "Hello")
-        }
+      let file = try folder.createFileIfNeeded(at: path)
+      XCTAssertEqual(try file.readAsString(), "Hello")
     }
-    
-    func testCreatingAndDeletingFolder() {
-        performTest {
-            // Verify that the folder doesn't exist
-            XCTAssertFalse(folder.containsSubfolder(named: "folder"))
-
-            // Create a folder and verify its properties
-            let subfolder = try folder.createSubfolder(named: "folder")
-            XCTAssertEqual(subfolder.name, "folder")
-            XCTAssertEqual(subfolder.path, folder.path + "folder/")
-            
-            // You should now be able to access the folder using its path and through the parent
-            _ = try Folder(path: subfolder.path)
-            XCTAssertTrue(folder.containsSubfolder(named: "folder"))
-            
-            // Put a file in the folder
-            let file = try subfolder.createFile(named: "file")
-            try XCTAssertEqual(file.read(), Data())
-            
-            try subfolder.delete()
-            
-            // Attempting to create a Folder instance with the path should now fail
-            try assert(Folder(path: subfolder.path), throwsErrorOfType: LocationError.self)
-            
-            // The file contained in the folder should now also be deleted
-            try assert(file.read(), throwsErrorOfType: ReadError.self)
-        }
+  }
+
+  func testCreatingAndDeletingFolder() {
+    performTest {
+      // Verify that the folder doesn't exist
+      XCTAssertFalse(folder.containsSubfolder(named: "folder"))
+
+      // Create a folder and verify its properties
+      let subfolder = try folder.createSubfolder(named: "folder")
+      XCTAssertEqual(subfolder.name, "folder")
+      XCTAssertEqual(subfolder.path, folder.path + "folder/")
+
+      // You should now be able to access the folder using its path and through the parent
+      _ = try Folder(path: subfolder.path)
+      XCTAssertTrue(folder.containsSubfolder(named: "folder"))
+
+      // Put a file in the folder
+      let file = try subfolder.createFile(named: "file")
+      try XCTAssertEqual(file.read(), Data())
+
+      try subfolder.delete()
+
+      // Attempting to create a Folder instance with the path should now fail
+      try assert(Folder(path: subfolder.path), throwsErrorOfType: LocationError.self)
+
+      // The file contained in the folder should now also be deleted
+      try assert(file.read(), throwsErrorOfType: ReadError.self)
     }
+  }
 
-    func testCreatingSubfolderAtPath() {
-        performTest {
-            let path = "a/b/c"
+  func testCreatingSubfolderAtPath() {
+    performTest {
+      let path = "a/b/c"
 
-            XCTAssertFalse(folder.containsSubfolder(at: path))
-            try folder.createSubfolder(at: path).createFile(named: "d.txt")
+      XCTAssertFalse(folder.containsSubfolder(at: path))
+      try folder.createSubfolder(at: path).createFile(named: "d.txt")
 
-            XCTAssertTrue(folder.containsSubfolder(at: path))
-            XCTAssertTrue(folder.containsSubfolder(named: "a"))
-            XCTAssertTrue(folder.containsSubfolder(at: "a/b"))
-            XCTAssertTrue(folder.containsFile(at: "a/b/c/d.txt"))
+      XCTAssertTrue(folder.containsSubfolder(at: path))
+      XCTAssertTrue(folder.containsSubfolder(named: "a"))
+      XCTAssertTrue(folder.containsSubfolder(at: "a/b"))
+      XCTAssertTrue(folder.containsFile(at: "a/b/c/d.txt"))
 
-            let subfolder = try folder.createSubfolderIfNeeded(at: path)
-            XCTAssertEqual(subfolder.files.names(), ["d.txt"])
-        }
+      let subfolder = try folder.createSubfolderIfNeeded(at: path)
+      XCTAssertEqual(subfolder.files.names(), ["d.txt"])
     }
+  }
 
-    func testDroppingLeadingSlashWhenCreatingSubfolderAtPath() {
-        performTest {
-            let path = "a/b/c"
+  func testDroppingLeadingSlashWhenCreatingSubfolderAtPath() {
+    performTest {
+      let path = "a/b/c"
 
-            XCTAssertFalse(folder.containsSubfolder(at: path))
-            try folder.createSubfolder(at: path).createFile(named: "d.txt")
+      XCTAssertFalse(folder.containsSubfolder(at: path))
+      try folder.createSubfolder(at: path).createFile(named: "d.txt")
 
-            XCTAssertTrue(folder.containsSubfolder(at: path))
-            XCTAssertTrue(folder.containsSubfolder(named: "a"))
-            XCTAssertTrue(folder.containsSubfolder(at: "/a/b"))
-            XCTAssertTrue(folder.containsFile(at: "/a/b/c/d.txt"))
+      XCTAssertTrue(folder.containsSubfolder(at: path))
+      XCTAssertTrue(folder.containsSubfolder(named: "a"))
+      XCTAssertTrue(folder.containsSubfolder(at: "/a/b"))
+      XCTAssertTrue(folder.containsFile(at: "/a/b/c/d.txt"))
 
-            let subfolder = try folder.createSubfolderIfNeeded(at: path)
-            XCTAssertEqual(subfolder.files.names(), ["d.txt"])
-        }
+      let subfolder = try folder.createSubfolderIfNeeded(at: path)
+      XCTAssertEqual(subfolder.files.names(), ["d.txt"])
     }
+  }
 
-    func testReadingFileAsString() {
-        performTest {
-            let file = try folder.createFile(named: "string", contents: "Hello".data(using: .utf8)!)
-            try XCTAssertEqual(file.readAsString(), "Hello")
-        }
+  func testReadingFileAsString() {
+    performTest {
+      let file = try folder.createFile(named: "string", contents: "Hello".data(using: .utf8)!)
+      try XCTAssertEqual(file.readAsString(), "Hello")
     }
+  }
 
-    func testReadingFileAsInt() {
-        performTest {
-            let intFile = try folder.createFile(named: "int", contents: "\(7)".data(using: .utf8)!)
-            try XCTAssertEqual(intFile.readAsInt(), 7)
+  func testReadingFileAsInt() {
+    performTest {
+      let intFile = try folder.createFile(named: "int", contents: "\(7)".data(using: .utf8)!)
+      try XCTAssertEqual(intFile.readAsInt(), 7)
 
-            let nonIntFile = try folder.createFile(named: "nonInt", contents: "Not an int".data(using: .utf8)!)
-            try assert(nonIntFile.readAsInt(), throwsErrorOfType: ReadError.self)
-        }
+      let nonIntFile = try folder.createFile(named: "nonInt", contents: "Not an int".data(using: .utf8)!)
+      try assert(nonIntFile.readAsInt(), throwsErrorOfType: ReadError.self)
     }
-    
-    func testRenamingFile() {
-        performTest {
-            let file = try folder.createFile(named: "file.json")
-            try file.rename(to: "renamedFile")
-            XCTAssertEqual(file.name, "renamedFile.json")
-            XCTAssertEqual(file.path, folder.path + "renamedFile.json")
-            XCTAssertEqual(file.extension, "json")
-            
-            // Now try renaming the file, replacing its extension
-            try file.rename(to: "other.txt", keepExtension: false)
-            XCTAssertEqual(file.name, "other.txt")
-            XCTAssertEqual(file.path, folder.path + "other.txt")
-            XCTAssertEqual(file.extension, "txt")
-        }
+  }
+
+  func testRenamingFile() {
+    performTest {
+      let file = try folder.createFile(named: "file.json")
+      try file.rename(to: "renamedFile")
+      XCTAssertEqual(file.name, "renamedFile.json")
+      XCTAssertEqual(file.path, folder.path + "renamedFile.json")
+      XCTAssertEqual(file.extension, "json")
+
+      // Now try renaming the file, replacing its extension
+      try file.rename(to: "other.txt", keepExtension: false)
+      XCTAssertEqual(file.name, "other.txt")
+      XCTAssertEqual(file.path, folder.path + "other.txt")
+      XCTAssertEqual(file.extension, "txt")
     }
-    
-    func testRenamingFileWithNameIncludingExtension() {
-        performTest {
-            let file = try folder.createFile(named: "file.json")
-            try file.rename(to: "renamedFile.json")
-            XCTAssertEqual(file.name, "renamedFile.json")
-            XCTAssertEqual(file.path, folder.path + "renamedFile.json")
-            XCTAssertEqual(file.extension, "json")
-        }
+  }
+
+  func testRenamingFileWithNameIncludingExtension() {
+    performTest {
+      let file = try folder.createFile(named: "file.json")
+      try file.rename(to: "renamedFile.json")
+      XCTAssertEqual(file.name, "renamedFile.json")
+      XCTAssertEqual(file.path, folder.path + "renamedFile.json")
+      XCTAssertEqual(file.extension, "json")
     }
-    
-    func testReadingFileWithRelativePath() {
-        performTest {
-            try folder.createFile(named: "file")
-            
-            // Make sure we're not already in the file's parent directory
-            XCTAssertNotEqual(FileManager.default.currentDirectoryPath, folder.path)
-            
-            XCTAssertTrue(FileManager.default.changeCurrentDirectoryPath(folder.path))
-            let file = try File(path: "file")
-            try XCTAssertEqual(file.read(), Data())
-        }
+  }
+
+  func testReadingFileWithRelativePath() {
+    performTest {
+      try folder.createFile(named: "file")
+
+      // Make sure we're not already in the file's parent directory
+      XCTAssertNotEqual(FileManager.default.currentDirectoryPath, folder.path)
+
+      XCTAssertTrue(FileManager.default.changeCurrentDirectoryPath(folder.path))
+      let file = try File(path: "file")
+      try XCTAssertEqual(file.read(), Data())
     }
-    
-    func testReadingFileWithTildePath() {
-        performTest {
-            try folder.createFile(named: "File")
-            let file = try File(path: "~/.filesTest/File")
-            try XCTAssertEqual(file.read(), Data())
-            XCTAssertEqual(file.path, folder.path + "File")
-
-            // Cleanup since we're performing a test in the actual home folder
-            try file.delete()
-        }
+  }
+
+  func testReadingFileWithTildePath() {
+    performTest {
+      try folder.createFile(named: "File")
+      let file = try File(path: "~/.filesTest/File")
+      try XCTAssertEqual(file.read(), Data())
+      XCTAssertEqual(file.path, folder.path + "File")
+
+      // Cleanup since we're performing a test in the actual home folder
+      try file.delete()
     }
+  }
 
-    func testReadingFileFromCurrentFoldersParent() {
-        performTest {
-            let subfolder = try folder.createSubfolder(named: "folder")
-            let file = try folder.createFile(named: "file")
+  func testReadingFileFromCurrentFoldersParent() {
+    performTest {
+      let subfolder = try folder.createSubfolder(named: "folder")
+      let file = try folder.createFile(named: "file")
 
-            // Move to the subfolder
-            XCTAssertNotEqual(FileManager.default.currentDirectoryPath, subfolder.path)
-            XCTAssertTrue(FileManager.default.changeCurrentDirectoryPath(subfolder.path))
+      // Move to the subfolder
+      XCTAssertNotEqual(FileManager.default.currentDirectoryPath, subfolder.path)
+      XCTAssertTrue(FileManager.default.changeCurrentDirectoryPath(subfolder.path))
 
-            try XCTAssertEqual(File(path: "../file"), file)
-        }
+      try XCTAssertEqual(File(path: "../file"), file)
     }
+  }
 
-    func testReadingFileWithMultipleParentReferencesWithinPath() {
-        performTest {
-            let subfolderA = try folder.createSubfolder(named: "A")
-            try folder.createSubfolder(named: "B")
-            let subfolderC = try folder.createSubfolder(named: "C")
-            let file = try subfolderC.createFile(named: "file")
+  func testReadingFileWithMultipleParentReferencesWithinPath() {
+    performTest {
+      let subfolderA = try folder.createSubfolder(named: "A")
+      try folder.createSubfolder(named: "B")
+      let subfolderC = try folder.createSubfolder(named: "C")
+      let file = try subfolderC.createFile(named: "file")
 
-            try XCTAssertEqual(File(path: subfolderA.path + "../B/../C/file"), file)
-        }
+      try XCTAssertEqual(File(path: subfolderA.path + "../B/../C/file"), file)
     }
-    
-    func testRenamingFolder() {
-        performTest {
-            let subfolder = try folder.createSubfolder(named: "folder")
-            try subfolder.rename(to: "renamedFolder")
-            XCTAssertEqual(subfolder.name, "renamedFolder")
-            XCTAssertEqual(subfolder.path, folder.path + "renamedFolder/")
-        }
+  }
+
+  func testRenamingFolder() {
+    performTest {
+      let subfolder = try folder.createSubfolder(named: "folder")
+      try subfolder.rename(to: "renamedFolder")
+      XCTAssertEqual(subfolder.name, "renamedFolder")
+      XCTAssertEqual(subfolder.path, folder.path + "renamedFolder/")
     }
+  }
 
-    func testAccesingFileByPath() {
-        performTest {
-            let subfolderA = try folder.createSubfolder(named: "A")
-            let subfolderB = try subfolderA.createSubfolder(named: "B")
-            let file = try subfolderB.createFile(named: "C")
-            try XCTAssertEqual(folder.file(at: "A/B/C"), file)
-        }
+  func testAccesingFileByPath() {
+    performTest {
+      let subfolderA = try folder.createSubfolder(named: "A")
+      let subfolderB = try subfolderA.createSubfolder(named: "B")
+      let file = try subfolderB.createFile(named: "C")
+      try XCTAssertEqual(folder.file(at: "A/B/C"), file)
     }
+  }
 
-    func testAccessingSubfolderByPath() {
-        performTest {
-            let subfolderA = try folder.createSubfolder(named: "A")
-            let subfolderB = try subfolderA.createSubfolder(named: "B")
-            let subfolderC = try subfolderB.createSubfolder(named: "C")
-            try XCTAssertEqual(folder.subfolder(at: "A/B/C"), subfolderC)
-        }
+  func testAccessingSubfolderByPath() {
+    performTest {
+      let subfolderA = try folder.createSubfolder(named: "A")
+      let subfolderB = try subfolderA.createSubfolder(named: "B")
+      let subfolderC = try subfolderB.createSubfolder(named: "C")
+      try XCTAssertEqual(folder.subfolder(at: "A/B/C"), subfolderC)
     }
+  }
 
-    func testEmptyingFolder() {
-        performTest {
-            try folder.createFile(named: "A")
-            try folder.createFile(named: "B")
-            XCTAssertEqual(folder.files.count(), 2)
+  func testEmptyingFolder() {
+    performTest {
+      try folder.createFile(named: "A")
+      try folder.createFile(named: "B")
+      XCTAssertEqual(folder.files.count(), 2)
 
-            try folder.empty()
-            XCTAssertEqual(folder.files.count(), 0)
-        }
+      try folder.empty()
+      XCTAssertEqual(folder.files.count(), 0)
     }
+  }
 
-    func testEmptyingFolderWithHiddenFiles() {
-        performTest {
-            let subfolder = try folder.createSubfolder(named: "folder")
+  func testEmptyingFolderWithHiddenFiles() {
+    performTest {
+      let subfolder = try folder.createSubfolder(named: "folder")
 
-            try subfolder.createFile(named: "A")
-            try subfolder.createFile(named: ".B")
-            XCTAssertEqual(subfolder.files.includingHidden.count(), 2)
+      try subfolder.createFile(named: "A")
+      try subfolder.createFile(named: ".B")
+      XCTAssertEqual(subfolder.files.includingHidden.count(), 2)
 
-            // Per default, hidden files should not be deleted
-            try subfolder.empty()
-            XCTAssertEqual(subfolder.files.includingHidden.count(), 1)
+      // Per default, hidden files should not be deleted
+      try subfolder.empty()
+      XCTAssertEqual(subfolder.files.includingHidden.count(), 1)
 
-            try subfolder.empty(includingHidden: true)
-            XCTAssertEqual(folder.files.count(), 0)
-        }
+      try subfolder.empty(includingHidden: true)
+      XCTAssertEqual(folder.files.count(), 0)
     }
-    
-    func testCheckingEmptyFolders() {
-        performTest {
-            let emptySubfolder = try folder.createSubfolder(named: "1")
-            XCTAssertTrue(emptySubfolder.isEmpty())
-            
-            let subfolderWithFile = try folder.createSubfolder(named: "2")
-            try subfolderWithFile.createFile(named: "A")
-            XCTAssertFalse(subfolderWithFile.isEmpty())
-            
-            let subfolderWithHiddenFile = try folder.createSubfolder(named: "3")
-            try subfolderWithHiddenFile.createFile(named: ".B")
-            XCTAssertTrue(subfolderWithHiddenFile.isEmpty())
-            XCTAssertFalse(subfolderWithHiddenFile.isEmpty(includingHidden: true))
-            
-            let subfolderWithFolder = try folder.createSubfolder(named: "3")
-            try subfolderWithFolder.createSubfolder(named: "4")
-            XCTAssertFalse(subfolderWithFile.isEmpty())
-        }
+  }
+
+  func testCheckingEmptyFolders() {
+    performTest {
+      let emptySubfolder = try folder.createSubfolder(named: "1")
+      XCTAssertTrue(emptySubfolder.isEmpty())
+
+      let subfolderWithFile = try folder.createSubfolder(named: "2")
+      try subfolderWithFile.createFile(named: "A")
+      XCTAssertFalse(subfolderWithFile.isEmpty())
+
+      let subfolderWithHiddenFile = try folder.createSubfolder(named: "3")
+      try subfolderWithHiddenFile.createFile(named: ".B")
+      XCTAssertTrue(subfolderWithHiddenFile.isEmpty())
+      XCTAssertFalse(subfolderWithHiddenFile.isEmpty(includingHidden: true))
+
+      let subfolderWithFolder = try folder.createSubfolder(named: "3")
+      try subfolderWithFolder.createSubfolder(named: "4")
+      XCTAssertFalse(subfolderWithFile.isEmpty())
     }
+  }
 
-    func testMovingFiles() {
-        performTest {
-            try folder.createFile(named: "A")
-            try folder.createFile(named: "B")
-            XCTAssertEqual(folder.files.count(), 2)
-            
-            let subfolder = try folder.createSubfolder(named: "folder")
-            try folder.files.move(to: subfolder)
-            try XCTAssertNotNil(subfolder.file(named: "A"))
-            try XCTAssertNotNil(subfolder.file(named: "B"))
-            XCTAssertEqual(folder.files.count(), 0)
-        }
+  func testMovingFiles() {
+    performTest {
+      try folder.createFile(named: "A")
+      try folder.createFile(named: "B")
+      XCTAssertEqual(folder.files.count(), 2)
+
+      let subfolder = try folder.createSubfolder(named: "folder")
+      try folder.files.move(to: subfolder)
+      try XCTAssertNotNil(subfolder.file(named: "A"))
+      try XCTAssertNotNil(subfolder.file(named: "B"))
+      XCTAssertEqual(folder.files.count(), 0)
     }
-    
-    func testCopyingFiles() {
-        performTest {
-            let file = try folder.createFile(named: "A")
-            try file.write("content")
-            
-            let subfolder = try folder.createSubfolder(named: "folder")
-            let copiedFile = try file.copy(to: subfolder)
-            try XCTAssertNotNil(folder.file(named: "A"))
-            try XCTAssertNotNil(subfolder.file(named: "A"))
-            try XCTAssertEqual(file.read(), subfolder.file(named: "A").read())
-            try XCTAssertEqual(copiedFile, subfolder.file(named: "A"))
-            XCTAssertEqual(folder.files.count(), 1)
-        }
+  }
+
+  func testCopyingFiles() {
+    performTest {
+      let file = try folder.createFile(named: "A")
+      try file.write("content")
+
+      let subfolder = try folder.createSubfolder(named: "folder")
+      let copiedFile = try file.copy(to: subfolder)
+      try XCTAssertNotNil(folder.file(named: "A"))
+      try XCTAssertNotNil(subfolder.file(named: "A"))
+      try XCTAssertEqual(file.read(), subfolder.file(named: "A").read())
+      try XCTAssertEqual(copiedFile, subfolder.file(named: "A"))
+      XCTAssertEqual(folder.files.count(), 1)
     }
+  }
 
-    func testMovingFolders() {
-        performTest {
-            let a = try folder.createSubfolder(named: "A")
-            let b = try a.createSubfolder(named: "B")
-            _ = try b.createSubfolder(named: "C")
+  func testMovingFolders() {
+    performTest {
+      let a = try folder.createSubfolder(named: "A")
+      let b = try a.createSubfolder(named: "B")
+      _ = try b.createSubfolder(named: "C")
 
-            try b.move(to: folder)
-            XCTAssertTrue(folder.containsSubfolder(named: "B"))
-            XCTAssertTrue(b.containsSubfolder(named: "C"))
-        }
+      try b.move(to: folder)
+      XCTAssertTrue(folder.containsSubfolder(named: "B"))
+      XCTAssertTrue(b.containsSubfolder(named: "C"))
     }
-    
-    func testCopyingFolders() {
-        performTest {
-            let copyingFolder = try folder.createSubfolder(named: "A")
-            
-            let subfolder = try folder.createSubfolder(named: "folder")
-            let copiedFolder = try copyingFolder.copy(to: subfolder)
-            XCTAssertTrue(folder.containsSubfolder(named: "A"))
-            XCTAssertTrue(subfolder.containsSubfolder(named: "A"))
-            XCTAssertEqual(copiedFolder, try subfolder.subfolder(named: "A"))
-            XCTAssertEqual(folder.subfolders.count(), 2)
-            XCTAssertEqual(subfolder.subfolders.count(), 1)
-        }
+  }
+
+  func testCopyingFolders() {
+    performTest {
+      let copyingFolder = try folder.createSubfolder(named: "A")
+
+      let subfolder = try folder.createSubfolder(named: "folder")
+      let copiedFolder = try copyingFolder.copy(to: subfolder)
+      XCTAssertTrue(folder.containsSubfolder(named: "A"))
+      XCTAssertTrue(subfolder.containsSubfolder(named: "A"))
+      XCTAssertEqual(copiedFolder, try subfolder.subfolder(named: "A"))
+      XCTAssertEqual(folder.subfolders.count(), 2)
+      XCTAssertEqual(subfolder.subfolders.count(), 1)
     }
-    
-    func testEnumeratingFiles() {
-        performTest {
-            try folder.createFile(named: "1")
-            try folder.createFile(named: "2")
-            try folder.createFile(named: "3")
-            
-            // Hidden files should be excluded by default
-            try folder.createFile(named: ".hidden")
-            
-            XCTAssertEqual(folder.files.names().sorted(), ["1", "2", "3"])
-            XCTAssertEqual(folder.files.count(), 3)
-        }
+  }
+
+  func testEnumeratingFiles() {
+    performTest {
+      try folder.createFile(named: "1")
+      try folder.createFile(named: "2")
+      try folder.createFile(named: "3")
+
+      // Hidden files should be excluded by default
+      try folder.createFile(named: ".hidden")
+
+      XCTAssertEqual(folder.files.names().sorted(), ["1", "2", "3"])
+      XCTAssertEqual(folder.files.count(), 3)
     }
-    
-    func testEnumeratingFilesIncludingHidden() {
-        performTest {
-            let subfolder = try folder.createSubfolder(named: "folder")
-            try subfolder.createFile(named: ".hidden")
-            try subfolder.createFile(named: "visible")
-            
-            let files = subfolder.files.includingHidden
-            XCTAssertEqual(files.names().sorted(), [".hidden", "visible"])
-            XCTAssertEqual(files.count(), 2)
-        }
+  }
+
+  func testEnumeratingFilesIncludingHidden() {
+    performTest {
+      let subfolder = try folder.createSubfolder(named: "folder")
+      try subfolder.createFile(named: ".hidden")
+      try subfolder.createFile(named: "visible")
+
+      let files = subfolder.files.includingHidden
+      XCTAssertEqual(files.names().sorted(), [".hidden", "visible"])
+      XCTAssertEqual(files.count(), 2)
     }
-    
-    func testEnumeratingFilesRecursively() {
-        performTest {
-            let subfolder1 = try folder.createSubfolder(named: "1")
-            let subfolder2 = try folder.createSubfolder(named: "2")
-            
-            let subfolder1A = try subfolder1.createSubfolder(named: "A")
-            let subfolder1B = try subfolder1.createSubfolder(named: "B")
-            
-            let subfolder2A = try subfolder2.createSubfolder(named: "A")
-            let subfolder2B = try subfolder2.createSubfolder(named: "B")
-            
-            try subfolder1.createFile(named: "File1")
-            try subfolder1A.createFile(named: "File1A")
-            try subfolder1B.createFile(named: "File1B")
-            try subfolder2.createFile(named: "File2")
-            try subfolder2A.createFile(named: "File2A")
-            try subfolder2B.createFile(named: "File2B")
-            
-            let expectedNames = ["File1", "File1A", "File1B", "File2", "File2A", "File2B"]
-            let sequence = folder.files.recursive
-            XCTAssertEqual(sequence.names(), expectedNames)
-            XCTAssertEqual(sequence.count(), 6)
-        }
+  }
+
+  func testEnumeratingFilesRecursively() {
+    performTest {
+      let subfolder1 = try folder.createSubfolder(named: "1")
+      let subfolder2 = try folder.createSubfolder(named: "2")
+
+      let subfolder1A = try subfolder1.createSubfolder(named: "A")
+      let subfolder1B = try subfolder1.createSubfolder(named: "B")
+
+      let subfolder2A = try subfolder2.createSubfolder(named: "A")
+      let subfolder2B = try subfolder2.createSubfolder(named: "B")
+
+      try subfolder1.createFile(named: "File1")
+      try subfolder1A.createFile(named: "File1A")
+      try subfolder1B.createFile(named: "File1B")
+      try subfolder2.createFile(named: "File2")
+      try subfolder2A.createFile(named: "File2A")
+      try subfolder2B.createFile(named: "File2B")
+
+      let expectedNames = ["File1", "File1A", "File1B", "File2", "File2A", "File2B"]
+      let sequence = folder.files.recursive
+      XCTAssertEqual(sequence.names(), expectedNames)
+      XCTAssertEqual(sequence.count(), 6)
     }
-    
-    func testEnumeratingSubfolders() {
-        performTest {
-            try folder.createSubfolder(named: "1")
-            try folder.createSubfolder(named: "2")
-            try folder.createSubfolder(named: "3")
-            
-            XCTAssertEqual(folder.subfolders.names(), ["1", "2", "3"])
-            XCTAssertEqual(folder.subfolders.count(), 3)
-        }
+  }
+
+  func testEnumeratingSubfolders() {
+    performTest {
+      try folder.createSubfolder(named: "1")
+      try folder.createSubfolder(named: "2")
+      try folder.createSubfolder(named: "3")
+
+      XCTAssertEqual(folder.subfolders.names(), ["1", "2", "3"])
+      XCTAssertEqual(folder.subfolders.count(), 3)
     }
-    
-    func testEnumeratingSubfoldersRecursively() {
-        performTest {
-            let subfolder1 = try folder.createSubfolder(named: "1")
-            let subfolder2 = try folder.createSubfolder(named: "2")
-            
-            try subfolder1.createSubfolder(named: "1A")
-            try subfolder1.createSubfolder(named: "1B")
-            
-            try subfolder2.createSubfolder(named: "2A")
-            try subfolder2.createSubfolder(named: "2B")
-            
-            let expectedNames = ["1", "1A", "1B", "2", "2A", "2B"]
-            let sequence = folder.subfolders.recursive
-            XCTAssertEqual(sequence.names().sorted(), expectedNames)
-            XCTAssertEqual(sequence.count(), 6)
-        }
+  }
+
+  func testEnumeratingSubfoldersRecursively() {
+    performTest {
+      let subfolder1 = try folder.createSubfolder(named: "1")
+      let subfolder2 = try folder.createSubfolder(named: "2")
+
+      try subfolder1.createSubfolder(named: "1A")
+      try subfolder1.createSubfolder(named: "1B")
+
+      try subfolder2.createSubfolder(named: "2A")
+      try subfolder2.createSubfolder(named: "2B")
+
+      let expectedNames = ["1", "1A", "1B", "2", "2A", "2B"]
+      let sequence = folder.subfolders.recursive
+      XCTAssertEqual(sequence.names().sorted(), expectedNames)
+      XCTAssertEqual(sequence.count(), 6)
     }
+  }
 
-    func testRenamingFoldersWhileEnumeratingSubfoldersRecursively() {
-        performTest {
-            let subfolder1 = try folder.createSubfolder(named: "1")
-            let subfolder2 = try folder.createSubfolder(named: "2")
+  func testRenamingFoldersWhileEnumeratingSubfoldersRecursively() {
+    performTest {
+      let subfolder1 = try folder.createSubfolder(named: "1")
+      let subfolder2 = try folder.createSubfolder(named: "2")
 
-            try subfolder1.createSubfolder(named: "1A")
-            try subfolder1.createSubfolder(named: "1B")
+      try subfolder1.createSubfolder(named: "1A")
+      try subfolder1.createSubfolder(named: "1B")
 
-            try subfolder2.createSubfolder(named: "2A")
-            try subfolder2.createSubfolder(named: "2B")
+      try subfolder2.createSubfolder(named: "2A")
+      try subfolder2.createSubfolder(named: "2B")
 
-            let sequence = folder.subfolders.recursive
+      let sequence = folder.subfolders.recursive
 
-            for folder in sequence {
-                try folder.rename(to: "Folder " + folder.name)
-            }
+      for folder in sequence {
+        try folder.rename(to: "Folder " + folder.name)
+      }
 
-            let expectedNames = ["Folder 1", "Folder 1A", "Folder 1B", "Folder 2", "Folder 2A", "Folder 2B"]
+      let expectedNames = ["Folder 1", "Folder 1A", "Folder 1B", "Folder 2", "Folder 2A", "Folder 2B"]
 
-            XCTAssertEqual(sequence.names().sorted(), expectedNames)
-            XCTAssertEqual(sequence.count(), 6)
-        }
+      XCTAssertEqual(sequence.names().sorted(), expectedNames)
+      XCTAssertEqual(sequence.count(), 6)
     }
-    
-    func testFirstAndLastInFileSequence() {
-        performTest {
-            try folder.createFile(named: "A")
-            try folder.createFile(named: "B")
-            try folder.createFile(named: "C")
-            
-            XCTAssertEqual(folder.files.first?.name, "A")
-            XCTAssertEqual(folder.files.last()?.name, "C")
-        }
+  }
+
+  func testFirstAndLastInFileSequence() {
+    performTest {
+      try folder.createFile(named: "A")
+      try folder.createFile(named: "B")
+      try folder.createFile(named: "C")
+
+      XCTAssertEqual(folder.files.first?.name, "A")
+      XCTAssertEqual(folder.files.last()?.name, "C")
     }
+  }
 
-    func testConvertingFileSequenceToRecursive() {
-        performTest {
-            try folder.createFile(named: "A")
-            try folder.createFile(named: "B")
+  func testConvertingFileSequenceToRecursive() {
+    performTest {
+      try folder.createFile(named: "A")
+      try folder.createFile(named: "B")
 
-            let subfolder = try folder.createSubfolder(named: "1")
-            try subfolder.createFile(named: "1A")
+      let subfolder = try folder.createSubfolder(named: "1")
+      try subfolder.createFile(named: "1A")
 
-            let names = folder.files.recursive.names()
-            XCTAssertEqual(names, ["A", "B", "1A"])
-        }
+      let names = folder.files.recursive.names()
+      XCTAssertEqual(names, ["A", "B", "1A"])
     }
+  }
 
-    func testModificationDate() {
-        performTest {
-            let subfolder = try folder.createSubfolder(named: "Folder")
-            XCTAssertTrue(subfolder.modificationDate.map(Calendar.current.isDateInToday) ?? false)
+  func testModificationDate() {
+    performTest {
+      let subfolder = try folder.createSubfolder(named: "Folder")
+      XCTAssertTrue(subfolder.modificationDate.map(Calendar.current.isDateInToday) ?? false)
 
-            let file = try folder.createFile(named: "File")
-            XCTAssertTrue(file.modificationDate.map(Calendar.current.isDateInToday) ?? false)
-        }
+      let file = try folder.createFile(named: "File")
+      XCTAssertTrue(file.modificationDate.map(Calendar.current.isDateInToday) ?? false)
     }
-    
-    func testParent() {
-        performTest {
-            try XCTAssertEqual(folder.createFile(named: "test").parent, folder)
-            
-            let subfolder = try folder.createSubfolder(named: "subfolder")
-            XCTAssertEqual(subfolder.parent, folder)
-            try XCTAssertEqual(subfolder.createFile(named: "test").parent, subfolder)
-        }
+  }
+
+  func testParent() {
+    performTest {
+      try XCTAssertEqual(folder.createFile(named: "test").parent, folder)
+
+      let subfolder = try folder.createSubfolder(named: "subfolder")
+      XCTAssertEqual(subfolder.parent, folder)
+      try XCTAssertEqual(subfolder.createFile(named: "test").parent, subfolder)
     }
-    
-    func testRootFolderParentIsNil() {
-        performTest {
-            try XCTAssertNil(Folder(path: "/").parent)
-        }
+  }
+
+  func testRootFolderParentIsNil() {
+    performTest {
+      try XCTAssertNil(Folder(path: "/").parent)
     }
-    
-    func testRootSubfolderParentIsRoot() {
-        performTest {
-            let rootFolder = try Folder(path: "/")
-            let subfolder = rootFolder.subfolders.first
-            XCTAssertEqual(subfolder?.parent, rootFolder)
-        }
+  }
+
+  func testRootSubfolderParentIsRoot() {
+    performTest {
+      let rootFolder = try Folder(path: "/")
+      let subfolder = rootFolder.subfolders.first
+      XCTAssertEqual(subfolder?.parent, rootFolder)
     }
-    
-    func testOpeningFileWithEmptyPathThrows() {
-        performTest {
-            try assert(File(path: ""), throwsErrorOfType: LocationError.self)
-        }
+  }
+
+  func testOpeningFileWithEmptyPathThrows() {
+    performTest {
+      try assert(File(path: ""), throwsErrorOfType: LocationError.self)
     }
-    
-    func testDeletingNonExistingFileThrows() {
-        performTest {
-            let file = try folder.createFile(named: "file")
-            try file.delete()
-            try assert(file.delete(), throwsErrorOfType: LocationError.self)
-        }
+  }
+
+  func testDeletingNonExistingFileThrows() {
+    performTest {
+      let file = try folder.createFile(named: "file")
+      try file.delete()
+      try assert(file.delete(), throwsErrorOfType: LocationError.self)
     }
-    
-    func testWritingDataToFile() {
-        performTest {
-            let file = try folder.createFile(named: "file")
-            try XCTAssertEqual(file.read(), Data())
-            
-            let data = "New content".data(using: .utf8)!
-            try file.write(data)
-            try XCTAssertEqual(file.read(), data)
-        }
+  }
+
+  func testWritingDataToFile() {
+    performTest {
+      let file = try folder.createFile(named: "file")
+      try XCTAssertEqual(file.read(), Data())
+
+      let data = "New content".data(using: .utf8)!
+      try file.write(data)
+      try XCTAssertEqual(file.read(), data)
     }
-    
-    func testWritingStringToFile() {
-        performTest {
-            let file = try folder.createFile(named: "file")
-            try XCTAssertEqual(file.read(), Data())
-            
-            try file.write("New content")
-            try XCTAssertEqual(file.read(), "New content".data(using: .utf8))
-        }
+  }
+
+  func testWritingStringToFile() {
+    performTest {
+      let file = try folder.createFile(named: "file")
+      try XCTAssertEqual(file.read(), Data())
+
+      try file.write("New content")
+      try XCTAssertEqual(file.read(), "New content".data(using: .utf8))
     }
+  }
 
-    func testAppendingDataToFile() {
-        performTest {
-            let file = try folder.createFile(named: "file")
-            let data = "Old content\n".data(using: .utf8)!
-            try file.write(data)
+  func testAppendingDataToFile() {
+    performTest {
+      let file = try folder.createFile(named: "file")
+      let data = "Old content\n".data(using: .utf8)!
+      try file.write(data)
 
-            let newData = "I'm the appended content 💯\n".data(using: .utf8)!
-            try file.append(newData)
-            try XCTAssertEqual(file.read(), "Old content\nI'm the appended content 💯\n".data(using: .utf8))
-        }
+      let newData = "I'm the appended content 💯\n".data(using: .utf8)!
+      try file.append(newData)
+      try XCTAssertEqual(file.read(), "Old content\nI'm the appended content 💯\n".data(using: .utf8))
     }
+  }
 
-    func testAppendingStringToFile() {
-        performTest {
-            let file = try folder.createFile(named: "file")
-            try file.write("Old content\n")
+  func testAppendingStringToFile() {
+    performTest {
+      let file = try folder.createFile(named: "file")
+      try file.write("Old content\n")
 
-            let newString = "I'm the appended content 💯\n"
-            try file.append(newString)
-            try XCTAssertEqual(file.read(), "Old content\nI'm the appended content 💯\n".data(using: .utf8))
-        }
+      let newString = "I'm the appended content 💯\n"
+      try file.append(newString)
+      try XCTAssertEqual(file.read(), "Old content\nI'm the appended content 💯\n".data(using: .utf8))
     }
-    
-    func testFileDescription() {
-        performTest {
-            let file = try folder.createFile(named: "file")
-            XCTAssertEqual(file.description, "File(name: file, path: \(folder.path)file)")
-        }
+  }
+
+  func testFileDescription() {
+    performTest {
+      let file = try folder.createFile(named: "file")
+      XCTAssertEqual(file.description, "File(name: file, path: \(folder.path)file)")
     }
-    
-    func testFolderDescription() {
-        performTest {
-            let subfolder = try folder.createSubfolder(named: "folder")
-            XCTAssertEqual(subfolder.description, "Folder(name: folder, path: \(folder.path)folder/)")
-        }
+  }
+
+  func testFolderDescription() {
+    performTest {
+      let subfolder = try folder.createSubfolder(named: "folder")
+      XCTAssertEqual(subfolder.description, "Folder(name: folder, path: \(folder.path)folder/)")
     }
+  }
 
-    func testFilesDescription() {
-        performTest {
-            let fileA = try folder.createFile(named: "fileA")
-            let fileB = try folder.createFile(named: "fileB")
-            XCTAssertEqual(folder.files.description, "\(fileA.description)\n\(fileB.description)")
-        }
+  func testFilesDescription() {
+    performTest {
+      let fileA = try folder.createFile(named: "fileA")
+      let fileB = try folder.createFile(named: "fileB")
+      XCTAssertEqual(folder.files.description, "\(fileA.description)\n\(fileB.description)")
     }
+  }
 
-    func testSubfoldersDescription() {
-        performTest {
-            let folderA = try folder.createSubfolder(named: "folderA")
-            let folderB = try folder.createSubfolder(named: "folderB")
-            XCTAssertEqual(folder.subfolders.description, "\(folderA.description)\n\(folderB.description)")
-        }
+  func testSubfoldersDescription() {
+    performTest {
+      let folderA = try folder.createSubfolder(named: "folderA")
+      let folderB = try folder.createSubfolder(named: "folderB")
+      XCTAssertEqual(folder.subfolders.description, "\(folderA.description)\n\(folderB.description)")
     }
+  }
 
-    func testMovingFolderContents() {
-        performTest {
-            let parentFolder = try folder.createSubfolder(named: "parentA")
-            try parentFolder.createSubfolder(named: "folderA")
-            try parentFolder.createSubfolder(named: "folderB")
-            try parentFolder.createFile(named: "fileA")
-            try parentFolder.createFile(named: "fileB")
+  func testMovingFolderContents() {
+    performTest {
+      let parentFolder = try folder.createSubfolder(named: "parentA")
+      try parentFolder.createSubfolder(named: "folderA")
+      try parentFolder.createSubfolder(named: "folderB")
+      try parentFolder.createFile(named: "fileA")
+      try parentFolder.createFile(named: "fileB")
 
-            XCTAssertEqual(parentFolder.subfolders.names(), ["folderA", "folderB"])
-            XCTAssertEqual(parentFolder.files.names(), ["fileA", "fileB"])
+      XCTAssertEqual(parentFolder.subfolders.names(), ["folderA", "folderB"])
+      XCTAssertEqual(parentFolder.files.names(), ["fileA", "fileB"])
 
-            let newParentFolder = try folder.createSubfolder(named: "parentB")
-            try parentFolder.moveContents(to: newParentFolder)
+      let newParentFolder = try folder.createSubfolder(named: "parentB")
+      try parentFolder.moveContents(to: newParentFolder)
 
-            XCTAssertEqual(parentFolder.subfolders.names(), [])
-            XCTAssertEqual(parentFolder.files.names(), [])
-            XCTAssertEqual(newParentFolder.subfolders.names(), ["folderA", "folderB"])
-            XCTAssertEqual(newParentFolder.files.names(), ["fileA", "fileB"])
-        }
+      XCTAssertEqual(parentFolder.subfolders.names(), [])
+      XCTAssertEqual(parentFolder.files.names(), [])
+      XCTAssertEqual(newParentFolder.subfolders.names(), ["folderA", "folderB"])
+      XCTAssertEqual(newParentFolder.files.names(), ["fileA", "fileB"])
     }
-    
-    func testMovingFolderHiddenContents() {
-        performTest {
-            let parentFolder = try folder.createSubfolder(named: "parent")
-            try parentFolder.createFile(named: ".hidden")
-            try parentFolder.createSubfolder(named: ".folder")
-            
-            XCTAssertEqual(parentFolder.files.includingHidden.names(), [".hidden"])
-            XCTAssertEqual(parentFolder.subfolders.includingHidden.names(), [".folder"])
-            
-            let newParentFolder = try folder.createSubfolder(named: "parentB")
-            try parentFolder.moveContents(to: newParentFolder, includeHidden: true)
-            
-            XCTAssertEqual(parentFolder.files.includingHidden.names(), [])
-            XCTAssertEqual(parentFolder.subfolders.includingHidden.names(), [])
-            XCTAssertEqual(newParentFolder.files.includingHidden.names(), [".hidden"])
-            XCTAssertEqual(newParentFolder.subfolders.includingHidden.names(), [".folder"])
-        }
-    }
+  }
+
+  func testMovingFolderHiddenContents() {
+    performTest {
+      let parentFolder = try folder.createSubfolder(named: "parent")
+      try parentFolder.createFile(named: ".hidden")
+      try parentFolder.createSubfolder(named: ".folder")
+
+      XCTAssertEqual(parentFolder.files.includingHidden.names(), [".hidden"])
+      XCTAssertEqual(parentFolder.subfolders.includingHidden.names(), [".folder"])
 
-    func testAccessingHomeFolder() {
-        XCTAssertNotNil(Folder.home)
+      let newParentFolder = try folder.createSubfolder(named: "parentB")
+      try parentFolder.moveContents(to: newParentFolder, includeHidden: true)
+
+      XCTAssertEqual(parentFolder.files.includingHidden.names(), [])
+      XCTAssertEqual(parentFolder.subfolders.includingHidden.names(), [])
+      XCTAssertEqual(newParentFolder.files.includingHidden.names(), [".hidden"])
+      XCTAssertEqual(newParentFolder.subfolders.includingHidden.names(), [".folder"])
     }
+  }
 
-    func testAccessingCurrentWorkingDirectory() {
-        performTest {
-            let folder = try Folder(path: "")
-            XCTAssertEqual(FileManager.default.currentDirectoryPath + "/", folder.path)
-            XCTAssertEqual(Folder.current, folder)
-        }
+  func testAccessingHomeFolder() {
+    XCTAssertNotNil(Folder.home)
+  }
+
+  func testAccessingCurrentWorkingDirectory() {
+    performTest {
+      let folder = try Folder(path: "")
+      XCTAssertEqual(FileManager.default.currentDirectoryPath + "/", folder.path)
+      XCTAssertEqual(Folder.current, folder)
     }
-    
-    func testNameExcludingExtensionWithLongFileName() {
-        performTest {
-            let file = try folder.createFile(named: "AVeryLongFileName.png")
-            XCTAssertEqual(file.nameExcludingExtension, "AVeryLongFileName")
-        }
+  }
+
+  func testNameExcludingExtensionWithLongFileName() {
+    performTest {
+      let file = try folder.createFile(named: "AVeryLongFileName.png")
+      XCTAssertEqual(file.nameExcludingExtension, "AVeryLongFileName")
     }
+  }
 
-    func testNameExcludingExtensionWithoutExtension() {
-        performTest {
-            let file = try folder.createFile(named: "File")
-            let subfolder = try folder.createSubfolder(named: "Subfolder")
+  func testNameExcludingExtensionWithoutExtension() {
+    performTest {
+      let file = try folder.createFile(named: "File")
+      let subfolder = try folder.createSubfolder(named: "Subfolder")
 
-            XCTAssertEqual(file.nameExcludingExtension, "File")
-            XCTAssertEqual(subfolder.nameExcludingExtension, "Subfolder")
-        }
+      XCTAssertEqual(file.nameExcludingExtension, "File")
+      XCTAssertEqual(subfolder.nameExcludingExtension, "Subfolder")
     }
+  }
 
-    func testRelativePaths() {
-        performTest {
-            let file = try folder.createFile(named: "FileA")
-            let subfolder = try folder.createSubfolder(named: "Folder")
-            let fileInSubfolder = try subfolder.createFile(named: "FileB")
+  func testRelativePaths() {
+    performTest {
+      let file = try folder.createFile(named: "FileA")
+      let subfolder = try folder.createSubfolder(named: "Folder")
+      let fileInSubfolder = try subfolder.createFile(named: "FileB")
 
-            XCTAssertEqual(file.path(relativeTo: folder), "FileA")
-            XCTAssertEqual(subfolder.path(relativeTo: folder), "Folder")
-            XCTAssertEqual(fileInSubfolder.path(relativeTo: folder), "Folder/FileB")
-        }
+      XCTAssertEqual(file.path(relativeTo: folder), "FileA")
+      XCTAssertEqual(subfolder.path(relativeTo: folder), "Folder")
+      XCTAssertEqual(fileInSubfolder.path(relativeTo: folder), "Folder/FileB")
     }
+  }
 
-    func testRelativePathIsAbsolutePathForNonParent() {
-        performTest {
-            let file = try folder.createFile(named: "FileA")
-            let subfolder = try folder.createSubfolder(named: "Folder")
+  func testRelativePathIsAbsolutePathForNonParent() {
+    performTest {
+      let file = try folder.createFile(named: "FileA")
+      let subfolder = try folder.createSubfolder(named: "Folder")
 
-            XCTAssertEqual(file.path(relativeTo: subfolder), file.path)
-        }
+      XCTAssertEqual(file.path(relativeTo: subfolder), file.path)
     }
+  }
 
-    func testCreateFileIfNeeded() {
-        performTest {
-            let fileA = try folder.createFileIfNeeded(withName: "file", contents: "Hello".data(using: .utf8)!)
-            let fileB = try folder.createFileIfNeeded(withName: "file", contents: "World".data(using: .utf8)!)
-            try XCTAssertEqual(fileA.readAsString(), "Hello")
-            try XCTAssertEqual(fileA.read(), fileB.read())
-        }
+  func testCreateFileIfNeeded() {
+    performTest {
+      let fileA = try folder.createFileIfNeeded(withName: "file", contents: "Hello".data(using: .utf8)!)
+      let fileB = try folder.createFileIfNeeded(withName: "file", contents: "World".data(using: .utf8)!)
+      try XCTAssertEqual(fileA.readAsString(), "Hello")
+      try XCTAssertEqual(fileA.read(), fileB.read())
     }
+  }
 
-    func testCreateFolderIfNeeded() {
-        performTest {
-            let subfolderA = try folder.createSubfolderIfNeeded(withName: "Subfolder")
-            try subfolderA.createFile(named: "file")
-            let subfolderB = try folder.createSubfolderIfNeeded(withName: subfolderA.name)
-            XCTAssertEqual(subfolderA, subfolderB)
-            XCTAssertEqual(subfolderA.files.count(), subfolderB.files.count())
-            XCTAssertEqual(subfolderA.files.first, subfolderB.files.first)
-        }
+  func testCreateFolderIfNeeded() {
+    performTest {
+      let subfolderA = try folder.createSubfolderIfNeeded(withName: "Subfolder")
+      try subfolderA.createFile(named: "file")
+      let subfolderB = try folder.createSubfolderIfNeeded(withName: subfolderA.name)
+      XCTAssertEqual(subfolderA, subfolderB)
+      XCTAssertEqual(subfolderA.files.count(), subfolderB.files.count())
+      XCTAssertEqual(subfolderA.files.first, subfolderB.files.first)
     }
+  }
 
-    func testCreateSubfolderIfNeeded() {
-        performTest {
-            let subfolderA = try folder.createSubfolderIfNeeded(withName: "folder")
-            try subfolderA.createFile(named: "file")
-            let subfolderB = try folder.createSubfolderIfNeeded(withName: "folder")
-            XCTAssertEqual(subfolderA, subfolderB)
-            XCTAssertEqual(subfolderA.files.count(), subfolderB.files.count())
-            XCTAssertEqual(subfolderA.files.first, subfolderB.files.first)
-        }
+  func testCreateSubfolderIfNeeded() {
+    performTest {
+      let subfolderA = try folder.createSubfolderIfNeeded(withName: "folder")
+      try subfolderA.createFile(named: "file")
+      let subfolderB = try folder.createSubfolderIfNeeded(withName: "folder")
+      XCTAssertEqual(subfolderA, subfolderB)
+      XCTAssertEqual(subfolderA.files.count(), subfolderB.files.count())
+      XCTAssertEqual(subfolderA.files.first, subfolderB.files.first)
     }
-    
-    func testCreatingFileWithString() {
-        performTest {
-            let file = try folder.createFile(named: "file", contents: Data("Hello world".utf8))
-            XCTAssertEqual(try file.readAsString(), "Hello world")
-        }
+  }
+
+  func testCreatingFileWithString() {
+    performTest {
+      let file = try folder.createFile(named: "file", contents: Data("Hello world".utf8))
+      XCTAssertEqual(try file.readAsString(), "Hello world")
     }
-    
-    func testUsingCustomFileManager() {
-        class FileManagerMock: FileManager {
-            var noFilesExist = false
-            
-            override func fileExists(atPath path: String, isDirectory: UnsafeMutablePointer<ObjCBool>?) -> Bool {
-                if noFilesExist {
-                    return false
-                }
-                
-                return super.fileExists(atPath: path, isDirectory: isDirectory)
-            }
-        }
-        
-        performTest {
-            let fileManager = FileManagerMock()
-            let subfolder = try folder.managedBy(fileManager).createSubfolder(named: UUID().uuidString)
-            let file = try subfolder.createFile(named: "file")
-            try XCTAssertEqual(file.read(), Data())
-        
-            // Mock that no files exist, which should call file lookups to fail
-            fileManager.noFilesExist = true
-            try assert(subfolder.file(named: "file"), throwsErrorOfType: LocationError.self)
+  }
+
+  func testUsingCustomFileManager() {
+    class FileManagerMock: FileManager {
+      var noFilesExist = false
+
+      override func fileExists(atPath path: String, isDirectory: UnsafeMutablePointer<ObjCBool>?) -> Bool {
+        if noFilesExist {
+          return false
         }
+
+        return super.fileExists(atPath: path, isDirectory: isDirectory)
+      }
     }
 
-    func testFolderContainsFile() {
-        performTest {
-            let subfolder = try folder.createSubfolder(named: "subfolder")
-            let fileA = try subfolder.createFile(named: "A")
-            XCTAssertFalse(folder.contains(fileA))
+    performTest {
+      let fileManager = FileManagerMock()
+      let subfolder = try folder.managedBy(fileManager).createSubfolder(named: UUID().uuidString)
+      let file = try subfolder.createFile(named: "file")
+      try XCTAssertEqual(file.read(), Data())
 
-            let fileB = try folder.createFile(named: "B")
-            XCTAssertTrue(folder.contains(fileB))
-        }
+      // Mock that no files exist, which should call file lookups to fail
+      fileManager.noFilesExist = true
+      try assert(subfolder.file(named: "file"), throwsErrorOfType: LocationError.self)
     }
+  }
 
-    func testFolderContainsSubfolder() {
-        performTest {
-            let subfolder = try folder.createSubfolder(named: "subfolder")
-            let subfolderA = try subfolder.createSubfolder(named: "A")
-            XCTAssertFalse(folder.contains(subfolderA))
+  func testFolderContainsFile() {
+    performTest {
+      let subfolder = try folder.createSubfolder(named: "subfolder")
+      let fileA = try subfolder.createFile(named: "A")
+      XCTAssertFalse(folder.contains(fileA))
 
-            let subfolderB = try folder.createSubfolder(named: "B")
-            XCTAssertTrue(folder.contains(subfolderB))
-        }
+      let fileB = try folder.createFile(named: "B")
+      XCTAssertTrue(folder.contains(fileB))
     }
+  }
 
-    func testErrorDescriptions() {
-        let missingError = FilesError(
-            path: "/some/path",
-            reason: LocationErrorReason.missing
-        )
-
-        XCTAssertEqual(missingError.description, """
-        Files encountered an error at '/some/path'.
-        Reason: missing
-        """)
-
-        let encodingError = FilesError(
-            path: "/some/path",
-            reason: WriteErrorReason.stringEncodingFailed("Hello")
-        )
-
-        XCTAssertEqual(encodingError.description, """
-        Files encountered an error at '/some/path'.
-        Reason: stringEncodingFailed(\"Hello\")
-        """)
-    }
-    
-    // MARK: - Utilities
-    
-    private func performTest(closure: () throws -> Void) {
-        do {
-            try folder.empty()
-            try closure()
-        } catch {
-            XCTFail("Unexpected error thrown: \(error)")
-        }
+  func testFolderContainsSubfolder() {
+    performTest {
+      let subfolder = try folder.createSubfolder(named: "subfolder")
+      let subfolderA = try subfolder.createSubfolder(named: "A")
+      XCTAssertFalse(folder.contains(subfolderA))
+
+      let subfolderB = try folder.createSubfolder(named: "B")
+      XCTAssertTrue(folder.contains(subfolderB))
     }
-    
-    private func assert<T, E: Error>(_ expression: @autoclosure () throws -> T,
-                                     throwsErrorOfType expectedError: E.Type) {
-        do {
-            _ = try expression()
-            XCTFail("Expected error to be thrown")
-        } catch {
-            XCTAssertTrue(error is E)
-        }
+  }
+
+  func testErrorDescriptions() {
+    let missingError = FilesError(
+      path: "/some/path",
+      reason: LocationErrorReason.missing)
+
+    XCTAssertEqual(missingError.description, """
+      Files encountered an error at '/some/path'.
+      Reason: missing
+      """)
+
+    let encodingError = FilesError(
+      path: "/some/path",
+      reason: WriteErrorReason.stringEncodingFailed("Hello"))
+
+    XCTAssertEqual(encodingError.description, """
+      Files encountered an error at '/some/path'.
+      Reason: stringEncodingFailed(\"Hello\")
+      """)
+  }
+
+  // MARK: Private
+
+  private var folder: Folder!
+
+  // MARK: - Utilities
+
+  private func performTest(closure: () throws -> Void) {
+    do {
+      try folder.empty()
+      try closure()
+    } catch {
+      XCTFail("Unexpected error thrown: \(error)")
+    }
+  }
+
+  private func assert<T, E: Error>(
+    _ expression: @autoclosure () throws -> T,
+    throwsErrorOfType _: E.Type)
+  {
+    do {
+      _ = try expression()
+      XCTFail("Expected error to be thrown")
+    } catch {
+      XCTAssertTrue(error is E)
     }
-    
-    // MARK: - Linux
-    
-    static var allTests = [
-        ("testCreatingAndDeletingFile", testCreatingAndDeletingFile),
-        ("testCreatingFileAtPath", testCreatingFileAtPath),
-        ("testDroppingLeadingSlashWhenCreatingFileAtPath", testDroppingLeadingSlashWhenCreatingFileAtPath),
-        ("testCreatingAndDeletingFolder", testCreatingAndDeletingFolder),
-        ("testCreatingSubfolderAtPath", testCreatingSubfolderAtPath),
-        ("testDroppingLeadingSlashWhenCreatingSubfolderAtPath", testDroppingLeadingSlashWhenCreatingSubfolderAtPath),
-        ("testReadingFileAsString", testReadingFileAsString),
-        ("testReadingFileAsInt", testReadingFileAsInt),
-        ("testRenamingFile", testRenamingFile),
-        ("testRenamingFileWithNameIncludingExtension", testRenamingFileWithNameIncludingExtension),
-        ("testReadingFileWithRelativePath", testReadingFileWithRelativePath),
-        ("testReadingFileWithTildePath", testReadingFileWithTildePath),
-        ("testReadingFileFromCurrentFoldersParent", testReadingFileFromCurrentFoldersParent),
-        ("testReadingFileWithMultipleParentReferencesWithinPath", testReadingFileWithMultipleParentReferencesWithinPath),
-        ("testRenamingFolder", testRenamingFolder),
-        ("testAccesingFileByPath", testAccesingFileByPath),
-        ("testAccessingSubfolderByPath", testAccessingSubfolderByPath),
-        ("testEmptyingFolder", testEmptyingFolder),
-        ("testEmptyingFolderWithHiddenFiles", testEmptyingFolderWithHiddenFiles),
-        ("testCheckingEmptyFolders", testCheckingEmptyFolders),
-        ("testMovingFiles", testMovingFiles),
-        ("testCopyingFiles", testCopyingFiles),
-        ("testCopyingFolders", testCopyingFolders),
-        ("testEnumeratingFiles", testEnumeratingFiles),
-        ("testEnumeratingFilesIncludingHidden", testEnumeratingFilesIncludingHidden),
-        ("testEnumeratingFilesRecursively", testEnumeratingFilesRecursively),
-        ("testEnumeratingSubfolders", testEnumeratingSubfolders),
-        ("testEnumeratingSubfoldersRecursively", testEnumeratingSubfoldersRecursively),
-        ("testRenamingFoldersWhileEnumeratingSubfoldersRecursively", testRenamingFoldersWhileEnumeratingSubfoldersRecursively),
-        ("testFirstAndLastInFileSequence", testFirstAndLastInFileSequence),
-        ("testConvertingFileSequenceToRecursive", testConvertingFileSequenceToRecursive),
-        ("testModificationDate", testModificationDate),
-        ("testParent", testParent),
-        ("testRootFolderParentIsNil", testRootFolderParentIsNil),
-        ("testRootSubfolderParentIsRoot", testRootSubfolderParentIsRoot),
-        ("testOpeningFileWithEmptyPathThrows", testOpeningFileWithEmptyPathThrows),
-        ("testDeletingNonExistingFileThrows", testDeletingNonExistingFileThrows),
-        ("testWritingDataToFile", testWritingDataToFile),
-        ("testWritingStringToFile", testWritingStringToFile),
-        ("testAppendingDataToFile", testAppendingDataToFile),
-        ("testAppendingStringToFile", testAppendingStringToFile),
-        ("testFileDescription", testFileDescription),
-        ("testFolderDescription", testFolderDescription),
-        ("testFilesDescription", testFilesDescription),
-        ("testSubfoldersDescription", testSubfoldersDescription),
-        ("testMovingFolderContents", testMovingFolderContents),
-        ("testMovingFolderHiddenContents", testMovingFolderHiddenContents),
-        ("testAccessingHomeFolder", testAccessingHomeFolder),
-        ("testAccessingCurrentWorkingDirectory", testAccessingCurrentWorkingDirectory),
-        ("testNameExcludingExtensionWithLongFileName", testNameExcludingExtensionWithLongFileName),
-        ("testRelativePaths", testRelativePaths),
-        ("testRelativePathIsAbsolutePathForNonParent", testRelativePathIsAbsolutePathForNonParent),
-        ("testCreateFileIfNeeded", testCreateFileIfNeeded),
-        ("testCreateFolderIfNeeded", testCreateFolderIfNeeded),
-        ("testCreateSubfolderIfNeeded", testCreateSubfolderIfNeeded),
-        ("testCreatingFileWithString", testCreatingFileWithString),
-        ("testUsingCustomFileManager", testUsingCustomFileManager),
-        ("testFolderContainsFile", testFolderContainsFile),
-        ("testFolderContainsSubfolder", testFolderContainsSubfolder),
-        ("testErrorDescriptions", testErrorDescriptions)
-    ]
+  }
 }
 
 #if os(macOS)
 extension FilesTests {
-    func testAccessingDocumentsFolder() {
-        XCTAssertNotNil(Folder.documents, "Documents folder should be available.")
-    }
+  func testAccessingDocumentsFolder() {
+    XCTAssertNotNil(Folder.documents, "Documents folder should be available.")
+  }
 }
 #endif
 
 #if os(iOS) || os(tvOS) || os(macOS)
 extension FilesTests {
-    func testAccessingLibraryFolder() {
-        XCTAssertNotNil(Folder.library, "Library folder should be available.")
-    }
+  func testAccessingLibraryFolder() {
+    XCTAssertNotNil(Folder.library, "Library folder should be available.")
+  }
 
-    func testResolvingFolderMatchingSearchPath() {
-        performTest {
-            // Real file I/O
-            XCTAssertNotNil(try Folder.matching(.cachesDirectory))
-            XCTAssertNotNil(try Folder.matching(.libraryDirectory))
+  func testResolvingFolderMatchingSearchPath() {
+    performTest {
+      // Real file I/O
+      XCTAssertNotNil(try Folder.matching(.cachesDirectory))
+      XCTAssertNotNil(try Folder.matching(.libraryDirectory))
 
-            // Mocked file I/O
-            final class FileManagerMock: FileManager {
-                var target: Folder?
+      // Mocked file I/O
+      final class FileManagerMock: FileManager {
+        var target: Folder?
 
-                override func urls(
-                    for directory: FileManager.SearchPathDirectory,
-                    in domainMask: FileManager.SearchPathDomainMask
-                ) -> [URL] {
-                    return target.map { [$0.url] } ?? []
-                }
-            }
-
-            let target = try folder.createSubfolder(named: "Target")
-
-            let fileManager = FileManagerMock()
-            fileManager.target = target
-
-            let resolved = try Folder.matching(.documentDirectory,
-                resolvedBy: fileManager
-            )
-
-            XCTAssertEqual(resolved, target)
+        override func urls(
+          for _: FileManager.SearchPathDirectory,
+          in _: FileManager.SearchPathDomainMask) -> [URL]
+        {
+          return target.map { [$0.url] } ?? []
         }
+      }
+
+      let target = try folder.createSubfolder(named: "Target")
+
+      let fileManager = FileManagerMock()
+      fileManager.target = target
+
+      let resolved = try Folder.matching(
+        .documentDirectory,
+        resolvedBy: fileManager)
+
+      XCTAssertEqual(resolved, target)
     }
+  }
 }
 #endif

--- a/Tests/LinuxMain.swift
+++ b/Tests/LinuxMain.swift
@@ -2,5 +2,5 @@ import XCTest
 @testable import FilesTests
 
 XCTMain([
-    testCase(FilesTests.allTests),
+  testCase(FilesTests.allTests),
 ])


### PR DESCRIPTION
To make it possible to use files in conjunction with Apples `swift-argument-parser` it would be handy if `File` and `Folder` confirm to `ExpressibleByArgument`. This way Files and Folder can be passed as options.

It is possible to extent Files to have this ability. The problem I faced was when I tried to make it conform to an Optional as well.

If you would consider this PR I can provide more info?

## Background on the optional

Basically I want the following code to compile

```swift
import ArgumentParser
struct DoMagic: ParsableCommand {
    @Option var someOptionalFolder: Folder?
    @Option var someOptionalFile: File?
}
```
The above does not compile as I cannot extend Optional twice, one time for `Folder` and another for `File`

```swift
extension Optional: ExpressibleByArgument where Wrapped == Folder {
    public init?(argument: String) {
        do {
            self = try Folder(path: argument)
        } catch {
            do {
                var currentURL = URL(fileURLWithPath: FileManager.default.currentDirectoryPath)
                currentURL = currentURL.appendingPathComponent(argument)
                self = try Folder(path: currentURL.path)
            } catch {
                print("\(error)")
                return nil
            }
        }
    }
}
```

So maybe adding a dependency on `swift-argument-parser` might be an issue. But It is handy for commandline tools.
