### PR TITLE
Create exists file/folder should throw error

### DIFF
--- a/Sources/Files.swift
+++ b/Sources/Files.swift
@@ -734,6 +734,9 @@ public extension Folder {
     /// - throws: `WriteError` if the operation couldn't be completed.
     @discardableResult
     func createSubfolder(at path: String) throws -> Folder {
+        guard !containsSubfolder(at: path) else {
+          throw FilesError(path: path, reason: LocationErrorReason.alreadyExists)
+        }
         return try storage.createSubfolder(at: path)
     }
 
@@ -743,6 +746,9 @@ public extension Folder {
     /// - throws: `WriteError` if the operation couldn't be completed.
     @discardableResult
     func createSubfolder(named name: String) throws -> Folder {
+        guard !containsSubfolder(named: name) else {
+          throw FilesError(path: path + name.removingPrefix("/"), reason: LocationErrorReason.alreadyExists)
+        }
         return try storage.createSubfolder(at: name)
     }
 
@@ -801,6 +807,9 @@ public extension Folder {
     /// - throws: `WriteError` if the operation couldn't be completed.
     @discardableResult
     func createFile(at path: String, contents: Data? = nil) throws -> File {
+        guard !containsFile(at: path) else {
+          throw FilesError(path: path, reason: LocationErrorReason.alreadyExists)
+        }
         return try storage.createFile(at: path, contents: contents)
     }
 
@@ -811,6 +820,9 @@ public extension Folder {
     /// - throws: `WriteError` if the operation couldn't be completed.
     @discardableResult
     func createFile(named fileName: String, contents: Data? = nil) throws -> File {
+        guard !containsFile(named: fileName) else {
+          throw FilesError(path: path + fileName.removingPrefix("/"), reason: LocationErrorReason.alreadyExists)
+        }
         return try storage.createFile(at: fileName, contents: contents)
     }
 
@@ -960,6 +972,8 @@ extension FilesError: CustomStringConvertible {
 public enum LocationErrorReason {
     /// The location couldn't be found.
     case missing
+    /// The location already has file/folder exists.
+    case alreadyExists
     /// An empty path was given when refering to a file.
     case emptyFilePath
     /// The user attempted to rename the file system's root folder.

--- a/Tests/FilesTests/FilesTests.swift
+++ b/Tests/FilesTests/FilesTests.swift
@@ -78,6 +78,9 @@ class FilesTests: XCTestCase {
             XCTAssertFalse(folder.containsFile(at: path))
             try folder.createFile(at: path, contents: Data("Hello".utf8))
 
+            // create existing file should throw error
+            XCTAssertThrowsError(try folder.createFile(at: path))
+
             XCTAssertTrue(folder.containsFile(at: path))
             XCTAssertTrue(folder.containsSubfolder(named: "a"))
             XCTAssertTrue(folder.containsSubfolder(at: "a/b"))
@@ -153,6 +156,9 @@ class FilesTests: XCTestCase {
 
             XCTAssertFalse(folder.containsSubfolder(at: path))
             try folder.createSubfolder(at: path).createFile(named: "d.txt")
+
+            // create existing folder should throw
+            XCTAssertThrowsError(try folder.createSubfolder(at: path))
 
             XCTAssertTrue(folder.containsSubfolder(at: path))
             XCTAssertTrue(folder.containsSubfolder(named: "a"))
@@ -332,17 +338,17 @@ class FilesTests: XCTestCase {
         performTest {
             let emptySubfolder = try folder.createSubfolder(named: "1")
             XCTAssertTrue(emptySubfolder.isEmpty())
-            
+
             let subfolderWithFile = try folder.createSubfolder(named: "2")
             try subfolderWithFile.createFile(named: "A")
             XCTAssertFalse(subfolderWithFile.isEmpty())
-            
+
             let subfolderWithHiddenFile = try folder.createSubfolder(named: "3")
             try subfolderWithHiddenFile.createFile(named: ".B")
             XCTAssertTrue(subfolderWithHiddenFile.isEmpty())
             XCTAssertFalse(subfolderWithHiddenFile.isEmpty(includingHidden: true))
-            
-            let subfolderWithFolder = try folder.createSubfolder(named: "3")
+
+            let subfolderWithFolder = try folder.createSubfolder(named: "4")
             try subfolderWithFolder.createSubfolder(named: "4")
             XCTAssertFalse(subfolderWithFile.isEmpty())
         }


### PR DESCRIPTION
To match the documentation of `createSubfolder` and `createFile` methods on
```
This method throws an error if a folder already exists at the given path.
```
```
This method throws an error if a file already exists at the given path.
```
It should throw error if file/folder exits.

The reason is when `withIntermediateDirectories` is set to `true` for `createDirectory(atPath:withIntermediateDirectories:attributes:)`, the FileManager doesn't throw error if path exists.