### PR TITLE
Fix copying files and folders

### DIFF
--- a/Sources/Files.swift
+++ b/Sources/Files.swift
@@ -273,7 +273,9 @@ fileprivate extension Storage {
 
     func copy(to newPath: String) throws {
         do {
-            try fileManager.copyItem(atPath: path, toPath: newPath)
+            try fileManager.copyItem(at: URL(fileURLWithPath: path),
+                                     to: URL(fileURLWithPath: newPath))
+
         } catch {
             throw LocationError(path: path, reason: .copyFailed(error))
         }


### PR DESCRIPTION
Fixes #137

- Since iOS 18.4 / macOS 15.4 it seems that when copying files it doesnt copy the nested files and folders
- It appears as though when it copied, it was flattening them causing issues

- This is particularly an issue with Publish as it no longer compiles correctly